### PR TITLE
feat: scaffold integrations vendor ledger

### DIFF
--- a/migrations/m4-integrations/001-integrations-ledger.sql
+++ b/migrations/m4-integrations/001-integrations-ledger.sql
@@ -1,0 +1,303 @@
+-- Integrations phase 1: vendor ledger, webhooks, and order scaffolding
+set check_function_bodies = off;
+
+-- Canonical vendors catalogue
+create table if not exists vendors (
+  id uuid primary key default gen_random_uuid(),
+  category text not null,
+  name text not null,
+  slug text unique,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1
+);
+
+create unique index if not exists vendors_slug_idx on vendors(slug) where slug is not null;
+
+-- Vendor accounts are tenant scoped credentials and configuration
+create table if not exists vendor_accounts (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vendor_id uuid not null references vendors(id) on delete cascade,
+  credentials_ref text not null,
+  sandbox_bool boolean not null default false,
+  status text not null default 'active',
+  metadata jsonb,
+  last_validated_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1,
+  constraint vendor_accounts_tenant_vendor_sandbox_key unique (tenant_id, vendor_id, sandbox_bool)
+);
+
+create index if not exists vendor_accounts_tenant_status_idx on vendor_accounts(tenant_id, status);
+
+-- Vendor requests record outbound calls to vendor services
+create table if not exists vendor_requests (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vendor_id uuid not null references vendors(id) on delete cascade,
+  vendor_account_id uuid references vendor_accounts(id) on delete set null,
+  loan_id uuid references loans(id) on delete set null,
+  actor_id uuid,
+  service text not null,
+  idempotency_key text not null,
+  external_id text,
+  payload_digest text,
+  payload_uri text,
+  payload bytea,
+  headers_json jsonb,
+  sent_at timestamptz,
+  completed_at timestamptz,
+  retry_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1,
+  constraint vendor_requests_idempotent_key unique (tenant_id, vendor_id, idempotency_key)
+);
+
+create index if not exists vendor_requests_tenant_loan_idx on vendor_requests(tenant_id, loan_id, created_at);
+create index if not exists vendor_requests_tenant_service_idx on vendor_requests(tenant_id, service);
+
+-- Vendor responses capture inbound payloads or polling responses
+create table if not exists vendor_responses (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null references vendor_requests(id) on delete cascade,
+  status text not null,
+  payload_uri text,
+  payload bytea,
+  error_code text,
+  error_message text,
+  received_at timestamptz not null default now(),
+  latency_ms integer,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1
+);
+
+create index if not exists vendor_responses_request_idx on vendor_responses(request_id);
+
+-- Webhook ledger captures inbound notifications
+create table if not exists webhooks (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  vendor_id uuid not null references vendors(id) on delete cascade,
+  request_id uuid references vendor_requests(id) on delete set null,
+  topic text not null,
+  received_sig text not null,
+  signature_digest text not null,
+  payload_uri text,
+  payload bytea,
+  received_at timestamptz not null default now(),
+  verified_bool boolean not null default false,
+  replayed_bool boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1,
+  constraint webhooks_signature_digest_unique unique (tenant_id, vendor_id, signature_digest)
+);
+
+create index if not exists webhooks_tenant_received_idx on webhooks(tenant_id, received_at desc);
+
+-- Orders table ensures integrations can drive lifecycle workflows
+create table if not exists orders (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  loan_id uuid references loans(id) on delete set null,
+  order_type text,
+  service text,
+  vendor_id uuid references vendors(id) on delete set null,
+  vendor_request_id uuid references vendor_requests(id) on delete set null,
+  vendor text,
+  status text,
+  request_json jsonb,
+  response_json jsonb,
+  sla_due_at timestamptz,
+  completed_at timestamptz,
+  cost numeric(12,2),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1
+);
+
+-- Extend orders to support integrations lifecycle metadata
+alter table orders
+  add column if not exists service text,
+  add column if not exists vendor_id uuid references vendors(id),
+  add column if not exists vendor_request_id uuid references vendor_requests(id),
+  add column if not exists request_json jsonb,
+  add column if not exists response_json jsonb,
+  add column if not exists sla_due_at timestamptz,
+  add column if not exists completed_at timestamptz,
+  add column if not exists cost numeric(12,2);
+
+create index if not exists orders_tenant_loan_created_idx on orders(tenant_id, loan_id, created_at);
+create index if not exists orders_tenant_service_idx on orders(tenant_id, service);
+
+-- Document enrichment for storage metadata
+alter table documents
+  add column if not exists "type" text,
+  add column if not exists filename text,
+  add column if not exists storage_uri text,
+  add column if not exists content_hash text,
+  add column if not exists classification text,
+  add column if not exists signed_at timestamptz;
+
+create index if not exists documents_tenant_loan_created_idx on documents(tenant_id, loan_id, created_at);
+create index if not exists documents_tenant_type_idx on documents(tenant_id, "type");
+
+-- Disclosures table (Loan Estimates, Closing Disclosures, etc.)
+create table if not exists disclosures (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  loan_id uuid references loans(id) on delete set null,
+  disclosure_type text,
+  disclosure_version integer,
+  issued_at timestamptz,
+  delivered_at timestamptz,
+  proof_uri text,
+  gates_snapshot jsonb,
+  status text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1
+);
+
+-- Disclosure lifecycle metadata
+alter table disclosures
+  add column if not exists disclosure_type text,
+  add column if not exists disclosure_version integer,
+  add column if not exists issued_at timestamptz,
+  add column if not exists proof_uri text,
+  add column if not exists gates_snapshot jsonb;
+
+create index if not exists disclosures_tenant_loan_issued_idx on disclosures(tenant_id, loan_id, issued_at);
+create index if not exists disclosures_tenant_type_idx on disclosures(tenant_id, disclosure_type);
+
+-- Compliance and SLA clocks
+create table if not exists clocks (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id uuid not null references tenants(id) on delete cascade,
+  loan_id uuid references loans(id) on delete set null,
+  clock_type text not null,
+  state text not null default 'running',
+  started_at timestamptz not null default now(),
+  due_at timestamptz,
+  stopped_at timestamptz,
+  reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer not null default 1
+);
+
+-- Clock enhancements for SLA tracking
+alter table clocks
+  add column if not exists state text not null default 'running',
+  add column if not exists due_at timestamptz,
+  add column if not exists reason text;
+
+create index if not exists clocks_tenant_loan_idx on clocks(tenant_id, loan_id);
+create index if not exists clocks_tenant_type_state_idx on clocks(tenant_id, clock_type, state);
+
+-- Row level security policies
+alter table vendor_accounts enable row level security;
+alter table vendor_accounts force row level security;
+create policy vendor_accounts_tenant_isolation on vendor_accounts
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+alter table vendor_requests enable row level security;
+alter table vendor_requests force row level security;
+create policy vendor_requests_tenant_isolation on vendor_requests
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+alter table vendor_responses enable row level security;
+alter table vendor_responses force row level security;
+create policy vendor_responses_tenant_isolation on vendor_responses
+  using (exists (
+    select 1
+      from vendor_requests vr
+     where vr.id = vendor_responses.request_id
+       and vr.tenant_id = app.current_tenant()
+  ))
+  with check (exists (
+    select 1
+      from vendor_requests vr
+     where vr.id = vendor_responses.request_id
+       and vr.tenant_id = app.current_tenant()
+  ));
+
+alter table webhooks enable row level security;
+alter table webhooks force row level security;
+create policy webhooks_tenant_isolation on webhooks
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+alter table orders enable row level security;
+alter table orders force row level security;
+create policy orders_tenant_isolation on orders
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+alter table disclosures enable row level security;
+alter table disclosures force row level security;
+create policy disclosures_tenant_isolation on disclosures
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+alter table clocks enable row level security;
+alter table clocks force row level security;
+create policy clocks_tenant_isolation on clocks
+  using (tenant_id = app.current_tenant())
+  with check (tenant_id = app.current_tenant());
+
+-- Updated-at triggers for new tables
+create trigger trg_vendor_accounts_updated
+  before update on vendor_accounts
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_vendor_requests_updated
+  before update on vendor_requests
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_vendor_responses_updated
+  before update on vendor_responses
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_webhooks_updated
+  before update on webhooks
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_vendors_updated
+  before update on vendors
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_orders_updated
+  before update on orders
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_disclosures_updated
+  before update on disclosures
+  for each row execute function app.updated_at_trigger();
+
+create trigger trg_clocks_updated
+  before update on clocks
+  for each row execute function app.updated_at_trigger();

--- a/migrations/m4-integrations/README.md
+++ b/migrations/m4-integrations/README.md
@@ -1,0 +1,13 @@
+# M4 – Integrations Ledger & Gateway Foundations
+
+This migration introduces the shared vendor catalog, multi-tenant vendor account bindings, the vendor request/response ledger, webhook journal, and enriched artifacts (orders, documents, clocks, disclosures) required for the Integrations phase.
+
+Key capabilities:
+
+- Canonical `vendors` catalog and tenant-scoped `vendor_accounts` with replay-safe credential storage references.
+- `vendor_requests` and `vendor_responses` tables with tamper-evident metadata, idempotency keys, payload digests, and request archival URIs.
+- Webhook ledger for signature dedupe with enforced row-level security and updated-at triggers.
+- Enriched operational tables (orders, documents, disclosures, clocks) with SLA and storage metadata to drive adapters.
+- Row-level security, indexes, and updated-at triggers aligned with the existing governance model.
+
+Apply this migration before deploying the webhook gateway, adapters, or UI consumers so downstream services can persist payloads and drive SLA-aware workflows.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,3 +31,93 @@ export interface FeatureFlagEvaluationContext {
   userId?: string;
   flag: string;
 }
+
+export type VendorCategory =
+  | 'credit'
+  | 'aus'
+  | 'appraisal'
+  | 'disclosure'
+  | 'document'
+  | 'data'
+  | 'other';
+
+export interface VendorDefinition {
+  id: string;
+  category: VendorCategory;
+  name: string;
+  slug?: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VendorAccountRef {
+  id: string;
+  tenantId: string;
+  vendorId: string;
+  sandbox: boolean;
+  status: string;
+  credentialsRef: string;
+  metadata?: Record<string, unknown>;
+  lastValidatedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type VendorServiceName =
+  | 'credit'
+  | 'aus'
+  | 'appraisal'
+  | 'edisclosure'
+  | 'flood'
+  | 'fraud'
+  | string;
+
+export interface VendorRequestLedgerEntry {
+  id: string;
+  tenantId: string;
+  vendorId: string;
+  vendorAccountId?: string;
+  loanId?: string;
+  actorId?: string;
+  service: VendorServiceName;
+  idempotencyKey: string;
+  externalId?: string;
+  payloadDigest?: string;
+  payloadUri?: string;
+  headers?: Record<string, unknown>;
+  sentAt?: string;
+  completedAt?: string;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VendorResponseLedgerEntry {
+  id: string;
+  requestId: string;
+  status: string;
+  payloadUri?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  receivedAt: string;
+  latencyMs?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookLedgerEntry {
+  id: string;
+  tenantId: string;
+  vendorId: string;
+  requestId?: string;
+  topic: string;
+  receivedSig: string;
+  signatureDigest: string;
+  payloadUri?: string;
+  receivedAt: string;
+  verified: boolean;
+  replayed: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,131 @@ model FeatureFlag {
   @@map("feature_flags")
 }
 
+model Vendor {
+  id        String           @id @default(uuid()) @db.Uuid
+  category  String
+  name      String
+  slug      String?          @unique
+  active    Boolean          @default(true)
+  createdAt DateTime         @map("created_at") @default(now())
+  updatedAt DateTime         @map("updated_at") @default(now()) @updatedAt
+  createdBy String?          @map("created_by") @db.Uuid
+  updatedBy String?          @map("updated_by") @db.Uuid
+  version   Int              @default(1)
+  accounts  VendorAccount[]
+  requests  VendorRequest[]
+  webhooks  Webhook[]
+  orders    Order[]
+
+  @@map("vendors")
+}
+
+model VendorAccount {
+  id             String          @id @default(uuid()) @db.Uuid
+  tenantId       String          @map("tenant_id") @db.Uuid
+  vendorId       String          @map("vendor_id") @db.Uuid
+  credentialsRef String          @map("credentials_ref")
+  sandbox        Boolean         @map("sandbox_bool") @default(false)
+  status         String?         @default("active")
+  metadata       Json?
+  lastValidatedAt DateTime?      @map("last_validated_at")
+  createdAt      DateTime        @map("created_at") @default(now())
+  updatedAt      DateTime        @map("updated_at") @default(now()) @updatedAt
+  createdBy      String?         @map("created_by") @db.Uuid
+  updatedBy      String?         @map("updated_by") @db.Uuid
+  version        Int             @default(1)
+  tenant         Tenant          @relation(fields: [tenantId], references: [id])
+  vendor         Vendor          @relation(fields: [vendorId], references: [id])
+  requests       VendorRequest[]
+
+  @@unique([tenantId, vendorId, sandbox])
+  @@index([tenantId, status])
+  @@map("vendor_accounts")
+}
+
+model VendorRequest {
+  id              String           @id @default(uuid()) @db.Uuid
+  tenantId        String           @map("tenant_id") @db.Uuid
+  vendorId        String           @map("vendor_id") @db.Uuid
+  vendorAccountId String?          @map("vendor_account_id") @db.Uuid
+  loanId          String?          @map("loan_id") @db.Uuid
+  actorId         String?          @map("actor_id") @db.Uuid
+  service         String
+  idempotencyKey  String           @map("idempotency_key")
+  externalId      String?          @map("external_id")
+  payloadDigest   String?          @map("payload_digest")
+  payloadUri      String?          @map("payload_uri")
+  payload         Bytes?           @db.Bytea
+  headers         Json?            @map("headers_json")
+  sentAt          DateTime?        @map("sent_at")
+  completedAt     DateTime?        @map("completed_at")
+  retryCount      Int              @map("retry_count") @default(0)
+  createdAt       DateTime         @map("created_at") @default(now())
+  updatedAt       DateTime         @map("updated_at") @default(now()) @updatedAt
+  createdBy       String?          @map("created_by") @db.Uuid
+  updatedBy       String?          @map("updated_by") @db.Uuid
+  version         Int              @default(1)
+  tenant          Tenant           @relation(fields: [tenantId], references: [id])
+  vendor          Vendor           @relation(fields: [vendorId], references: [id])
+  vendorAccount   VendorAccount?   @relation(fields: [vendorAccountId], references: [id])
+  loan            Loan?            @relation(fields: [loanId], references: [id])
+  response        VendorResponse?  @relation("VendorRequestResponse")
+  webhooks        Webhook[]
+  orders          Order[]
+
+  @@unique([tenantId, vendorId, idempotencyKey])
+  @@index([tenantId, loanId, createdAt])
+  @@index([tenantId, service])
+  @@map("vendor_requests")
+}
+
+model VendorResponse {
+  id          String         @id @default(uuid()) @db.Uuid
+  requestId   String         @map("request_id") @db.Uuid
+  status      String
+  payloadUri  String?        @map("payload_uri")
+  payload     Bytes?         @db.Bytea
+  errorCode   String?        @map("error_code")
+  errorMessage String?       @map("error_message")
+  receivedAt  DateTime       @map("received_at") @default(now())
+  latencyMs   Int?           @map("latency_ms")
+  createdAt   DateTime       @map("created_at") @default(now())
+  updatedAt   DateTime       @map("updated_at") @default(now()) @updatedAt
+  createdBy   String?        @map("created_by") @db.Uuid
+  updatedBy   String?        @map("updated_by") @db.Uuid
+  version     Int            @default(1)
+  request     VendorRequest  @relation("VendorRequestResponse", fields: [requestId], references: [id], onDelete: Cascade)
+
+  @@map("vendor_responses")
+}
+
+model Webhook {
+  id              String         @id @default(uuid()) @db.Uuid
+  tenantId        String         @map("tenant_id") @db.Uuid
+  vendorId        String         @map("vendor_id") @db.Uuid
+  requestId       String?        @map("request_id") @db.Uuid
+  topic           String
+  receivedSig     String         @map("received_sig")
+  signatureDigest String         @map("signature_digest")
+  payloadUri      String?        @map("payload_uri")
+  payload         Bytes?         @db.Bytea
+  receivedAt      DateTime       @map("received_at") @default(now())
+  verified        Boolean        @map("verified_bool") @default(false)
+  replayed        Boolean        @map("replayed_bool") @default(false)
+  createdAt       DateTime       @map("created_at") @default(now())
+  updatedAt       DateTime       @map("updated_at") @default(now()) @updatedAt
+  createdBy       String?        @map("created_by") @db.Uuid
+  updatedBy       String?        @map("updated_by") @db.Uuid
+  version         Int            @default(1)
+  tenant          Tenant         @relation(fields: [tenantId], references: [id])
+  vendor          Vendor         @relation(fields: [vendorId], references: [id])
+  request         VendorRequest? @relation(fields: [requestId], references: [id])
+
+  @@unique([tenantId, vendorId, signatureDigest])
+  @@index([tenantId, receivedAt])
+  @@map("webhooks")
+}
+
 model ApiKey {
   id        String   @id @default(uuid()) @db.Uuid
   tenantId  String   @map("tenant_id") @db.Uuid
@@ -408,10 +533,16 @@ model Document {
   id        String   @id @default(uuid()) @db.Uuid
   tenantId  String   @map("tenant_id") @db.Uuid
   loanId    String?  @map("loan_id") @db.Uuid
+  documentType String? @map("type")
   category  String?
+  filename  String?   @map("filename")
   uri       String?
+  storageUri String?  @map("storage_uri")
+  contentHash String? @map("content_hash")
   status    String?
   dataClassification String @map("data_classification") @default("internal")
+  classification String? @map("classification")
+  signedAt  DateTime? @map("signed_at")
   createdAt DateTime  @map("created_at") @default(now())
   updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
   createdBy String?   @map("created_by") @db.Uuid
@@ -420,6 +551,8 @@ model Document {
   loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
 
   @@index([tenantId, status])
+  @@index([tenantId, loanId, createdAt])
+  @@index([tenantId, documentType])
   @@map("documents")
 }
 
@@ -489,8 +622,11 @@ model Clock {
   tenantId  String   @map("tenant_id") @db.Uuid
   loanId    String?  @map("loan_id") @db.Uuid
   clockType String   @map("clock_type")
+  state     String   @default("running")
   startedAt DateTime @map("started_at") @default(now())
+  dueAt     DateTime? @map("due_at")
   stoppedAt DateTime? @map("stopped_at")
+  reason    String?   @map("reason")
   createdAt DateTime  @map("created_at") @default(now())
   updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
   createdBy String?   @map("created_by") @db.Uuid
@@ -498,6 +634,8 @@ model Clock {
   version   Int       @default(1)
   loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId, loanId])
+  @@index([tenantId, clockType, state])
   @@map("clocks")
 }
 
@@ -506,7 +644,11 @@ model Disclosure {
   tenantId  String   @map("tenant_id") @db.Uuid
   loanId    String?  @map("loan_id") @db.Uuid
   disclosureType String? @map("disclosure_type")
+  disclosureVersion Int? @map("disclosure_version")
+  issuedAt  DateTime? @map("issued_at")
   deliveredAt DateTime? @map("delivered_at")
+  proofUri  String?  @map("proof_uri")
+  gatesSnapshot Json? @map("gates_snapshot")
   status    String?
   createdAt DateTime  @map("created_at") @default(now())
   updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
@@ -515,6 +657,8 @@ model Disclosure {
   version   Int       @default(1)
   loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId, loanId, issuedAt])
+  @@index([tenantId, disclosureType])
   @@map("disclosures")
 }
 
@@ -523,15 +667,27 @@ model Order {
   tenantId  String   @map("tenant_id") @db.Uuid
   loanId    String?  @map("loan_id") @db.Uuid
   orderType String?  @map("order_type")
+  service   String?  @map("service")
+  vendorId  String?  @map("vendor_id") @db.Uuid
+  vendorRequestId String? @map("vendor_request_id") @db.Uuid
   vendor    String?
   status    String?
+  requestJson Json?  @map("request_json")
+  responseJson Json? @map("response_json")
+  slaDueAt  DateTime? @map("sla_due_at")
+  completedAt DateTime? @map("completed_at")
+  cost      Decimal?  @db.Decimal(12, 2)
   createdAt DateTime  @map("created_at") @default(now())
   updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
   createdBy String?   @map("created_by") @db.Uuid
   updatedBy String?   @map("updated_by") @db.Uuid
   version   Int       @default(1)
   loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
+  vendorRef Vendor?   @relation(fields: [vendorId], references: [id])
+  vendorRequest VendorRequest? @relation(fields: [vendorRequestId], references: [id])
 
+  @@index([tenantId, loanId, createdAt])
+  @@index([tenantId, service])
   @@map("orders")
 }
 


### PR DESCRIPTION
## Summary
- introduce Prisma models for vendors, vendor accounts, requests/responses, and webhooks with multi-tenant indexes and relations
- add the M4 integrations migration to create the vendor ledger tables, enforce RLS, and enrich orders/documents/disclosures/clocks for adapter workflows
- extend shared type definitions with vendor and webhook ledger interfaces for downstream services

## Testing
- not run (schema/type updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e19b6fcc948332a52dc4562a254e75