### PR TITLE
feat: implement M6 tasks queues and orders scaffolding

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,9 +3,17 @@ import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './common/prisma.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { LoansModule } from './modules/loans/loans.module.js';
+import { OperationsModule } from './modules/operations/operations.module.js';
 import { AuthModule } from './middleware/auth.module.js';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), PrismaModule, AuthModule, HealthModule, LoansModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    PrismaModule,
+    AuthModule,
+    HealthModule,
+    LoansModule,
+    OperationsModule,
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/middleware/idempotency.interceptor.ts
+++ b/apps/api/src/middleware/idempotency.interceptor.ts
@@ -3,6 +3,7 @@ import { Observable, from } from 'rxjs';
 import { tap, switchMap } from 'rxjs/operators';
 import { PrismaService } from '../common/prisma.service.js';
 import { createHash } from 'node:crypto';
+import { OrderStatus } from '@prisma/client';
 
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
@@ -27,13 +28,13 @@ export class IdempotencyInterceptor implements NestInterceptor {
           tenantId,
           keyHash,
           requestHash,
-          status: 'PENDING',
+          status: OrderStatus.PENDING,
         },
         update: {},
       }),
     ).pipe(
       switchMap((record) => {
-        if (record.status === 'COMPLETED') {
+        if (record.status === OrderStatus.COMPLETED) {
           throw new ConflictException({ message: 'Idempotent replay', code: 'IDEMPOTENT_REPLAY' });
         }
 
@@ -45,7 +46,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
               data: {
                 responseHash,
                 responsePayload: response,
-                status: 'COMPLETED',
+                status: OrderStatus.COMPLETED,
               },
             });
           }),

--- a/apps/api/src/modules/operations/dto/order.dto.ts
+++ b/apps/api/src/modules/operations/dto/order.dto.ts
@@ -1,0 +1,49 @@
+export type OrderServiceType = 'APPRAISAL' | 'TITLE' | 'FLOOD' | 'MI' | 'SSA89' | '4506-C';
+export type OrderStatusType = 'DRAFT' | 'SUBMITTED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'CANCELED';
+
+export interface OrderResponse {
+  id: string;
+  loanId?: string | null;
+  service: OrderServiceType;
+  status: OrderStatusType;
+  vendorId?: string | null;
+  vendorAccountId?: string | null;
+  slaDueAt?: string | null;
+  cost?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrderListResponse {
+  data: OrderResponse[];
+  total: number;
+}
+
+export interface OrderCreateRequest {
+  loanId: string;
+  service: OrderServiceType;
+  vendorId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OrderBulkRequest {
+  loanIds: string[];
+  service: 'FLOOD';
+}
+
+export interface OrderRetryResponse {
+  id: string;
+  attempt: number;
+  scheduledAt: string;
+}
+
+export interface DlqEntryResponse {
+  id: string;
+  source: string;
+  refId?: string | null;
+  reasonCode: string;
+  attempts: number;
+  status: 'PENDING' | 'REPLAYED' | 'ARCHIVED';
+  firstSeenAt: string;
+  lastSeenAt: string;
+}

--- a/apps/api/src/modules/operations/dto/sla.dto.ts
+++ b/apps/api/src/modules/operations/dto/sla.dto.ts
@@ -1,0 +1,14 @@
+export interface SlaHeatmapCell {
+  bucket: string;
+  total: number;
+  warning: number;
+  overdue: number;
+  query: string;
+}
+
+export interface SlaHeatmapResponse {
+  scope: 'tasks' | 'orders';
+  range: 'week' | 'month';
+  cells: SlaHeatmapCell[];
+  atRisk: string[];
+}

--- a/apps/api/src/modules/operations/dto/task.dto.ts
+++ b/apps/api/src/modules/operations/dto/task.dto.ts
@@ -1,0 +1,64 @@
+export interface TaskResponse {
+  id: string;
+  loanId?: string | null;
+  ownerUserId?: string | null;
+  queueKey: string;
+  type: string;
+  state: 'NEW' | 'IN_PROGRESS' | 'BLOCKED' | 'DONE';
+  priority: number;
+  dueAt?: string | null;
+  slaDueAt?: string | null;
+  tags: string[];
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskListResponse {
+  data: TaskResponse[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+  };
+}
+
+export interface TaskBulkUpdateRequest {
+  taskIds: string[];
+  updates: {
+    ownerUserId?: string | null;
+    dueAt?: string | null;
+    tags?: string[];
+    priority?: number;
+  };
+}
+
+export interface QueueDefinitionResponse {
+  key: string;
+  name: string;
+  skills: string[];
+  routing: Record<string, unknown>;
+  aggregates: {
+    total: number;
+    new: number;
+    inProgress: number;
+    blocked: number;
+    overdue: number;
+  };
+}
+
+export interface QueueListResponse {
+  data: QueueDefinitionResponse[];
+  updatedAt: string;
+}
+
+export interface RouteTaskRequest {
+  taskId: string;
+  preferredQueues?: string[];
+  skills?: string[];
+}
+
+export interface RouteTaskResponse {
+  queueKey: string;
+  ownerUserId?: string | null;
+}

--- a/apps/api/src/modules/operations/operations.module.ts
+++ b/apps/api/src/modules/operations/operations.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TasksService } from './tasks.service.js';
+import { OrdersService } from './orders.service.js';
+import { WebhooksService } from './webhooks.service.js';
+import { SlaService } from './sla.service.js';
+import { TasksController } from './tasks.controller.js';
+import { OrdersController } from './orders.controller.js';
+import { WebhooksController } from './webhooks.controller.js';
+import { SlaController } from './sla.controller.js';
+
+@Module({
+  controllers: [TasksController, OrdersController, WebhooksController, SlaController],
+  providers: [TasksService, OrdersService, WebhooksService, SlaService],
+})
+export class OperationsModule {}

--- a/apps/api/src/modules/operations/orders.controller.ts
+++ b/apps/api/src/modules/operations/orders.controller.ts
@@ -1,0 +1,109 @@
+import { BadRequestException, Body, Controller, Get, Headers, Param, Post, Query, Req } from '@nestjs/common';
+import { OrdersService } from './orders.service.js';
+import { FastifyRequest } from 'fastify';
+import { DlqEntryStatus, OrderStatus } from '@prisma/client';
+import {
+  DlqEntryResponse,
+  OrderBulkRequest,
+  OrderCreateRequest,
+  OrderListResponse,
+  OrderResponse,
+  OrderRetryResponse,
+} from './dto/order.dto.js';
+
+interface TenantRequest extends FastifyRequest {
+  tenant: { tenantId: string };
+}
+
+@Controller('v1')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get('orders')
+  async listOrders(
+    @Req() request: TenantRequest,
+    @Query('service') service?: string,
+    @Query('status') status?: string,
+    @Query('loanId') loanId?: string,
+  ): Promise<OrderListResponse> {
+    const filters = {
+      service: service ?? undefined,
+      status: status ? (status.toUpperCase() as OrderStatus) : undefined,
+      loanId,
+    };
+    return this.ordersService.listOrders(request.tenant.tenantId, filters);
+  }
+
+  @Post('orders')
+  async createOrder(
+    @Req() request: TenantRequest,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Body() body: OrderCreateRequest,
+  ): Promise<OrderResponse> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.ordersService.createOrder(request.tenant.tenantId, idempotencyKey, body);
+  }
+
+  @Post(['orders:bulk', 'orders/bulk'])
+  async bulkFlood(
+    @Req() request: TenantRequest,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Body() body: OrderBulkRequest,
+  ): Promise<{ accepted: number }> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.ordersService.bulkCreate(request.tenant.tenantId, idempotencyKey, body);
+  }
+
+  @Post(['orders/:id:retry', 'orders/:id/retry'])
+  async retryOrder(
+    @Req() request: TenantRequest,
+    @Param('id') id: string,
+    @Headers('idempotency-key') idempotencyKey: string,
+  ): Promise<OrderRetryResponse> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.ordersService.retryOrder(request.tenant.tenantId, idempotencyKey, id);
+  }
+
+  @Post('loans/:loanId/orders')
+  async createOrderForLoan(
+    @Req() request: TenantRequest,
+    @Param('loanId') loanId: string,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Body() body: Omit<OrderCreateRequest, 'loanId'>,
+  ): Promise<OrderResponse> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.ordersService.createOrder(request.tenant.tenantId, idempotencyKey, { ...body, loanId });
+  }
+
+  @Get('dlq')
+  async listDlq(
+    @Req() request: TenantRequest,
+    @Query('status') status?: string,
+  ): Promise<{ data: DlqEntryResponse[] }> {
+    const entries = await this.ordersService.listDlq(
+      request.tenant.tenantId,
+      status ? (status.toUpperCase() as DlqEntryStatus) : undefined,
+    );
+    return { data: entries };
+  }
+
+  @Post(['dlq/:id:replay', 'dlq/:id/replay'])
+  async replay(
+    @Req() request: TenantRequest,
+    @Param('id') id: string,
+    @Headers('idempotency-key') idempotencyKey: string,
+  ): Promise<DlqEntryResponse> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.ordersService.replayDlq(request.tenant.tenantId, idempotencyKey, id);
+  }
+}

--- a/apps/api/src/modules/operations/orders.service.ts
+++ b/apps/api/src/modules/operations/orders.service.ts
@@ -1,0 +1,337 @@
+import crypto from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma.service.js';
+import { createLogger } from '@haizel/observability';
+import { trace } from '@opentelemetry/api';
+import { DlqEntryStatus, OrderService, OrderStatus } from '@prisma/client';
+import {
+  DlqEntryResponse,
+  OrderBulkRequest,
+  OrderCreateRequest,
+  OrderListResponse,
+  OrderResponse,
+  OrderRetryResponse,
+} from './dto/order.dto.js';
+
+interface OrderFilters {
+  service?: string;
+  status?: OrderStatus;
+  loanId?: string;
+}
+
+@Injectable()
+export class OrdersService {
+  private readonly logger = createLogger('api.orders');
+  private readonly tracer = trace.getTracer('api.orders');
+  private readonly idempotencyCache = new Map<string, { createdAt: number }>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listOrders(tenantId: string, filters: OrderFilters = {}): Promise<OrderListResponse> {
+    return await this.tracer.startActiveSpan('orders.list', async (span) => {
+      try {
+        const where = {
+          tenantId,
+          service: filters.service ? this.normalizeService(filters.service) : undefined,
+          status: filters.status,
+          loanId: filters.loanId,
+        } satisfies Record<string, unknown>;
+
+        const [total, orders] = await this.prisma.$transaction([
+          this.prisma.order.count({ where }),
+          this.prisma.order.findMany({
+            where,
+            orderBy: { createdAt: 'desc' },
+          }),
+        ]);
+
+        const data: OrderResponse[] = orders.map((order) => ({
+          id: order.id,
+          loanId: order.loanId,
+          service: this.presentService(order.service),
+          status: order.status,
+          vendorId: order.vendorId,
+          vendorAccountId: order.vendorAccountId,
+          slaDueAt: order.slaDueAt?.toISOString() ?? null,
+          cost: order.cost ? Number(order.cost) : null,
+          createdAt: order.createdAt.toISOString(),
+          updatedAt: order.updatedAt.toISOString(),
+        }));
+
+        span.setAttributes({ 'app.orders.total': total });
+        return { data, total } satisfies OrderListResponse;
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async createOrder(
+    tenantId: string,
+    idempotencyKey: string,
+    payload: OrderCreateRequest,
+  ): Promise<OrderResponse> {
+    return await this.tracer.startActiveSpan('orders.create', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          const existing = await this.prisma.order.findFirst({
+            where: { tenantId, loanId: payload.loanId, service: this.normalizeService(payload.service) },
+            orderBy: { createdAt: 'desc' },
+          });
+          if (existing) {
+            return this.mapOrder(existing);
+          }
+        }
+
+        const vendorId = payload.vendorId ?? (await this.ensureDefaultVendor(tenantId));
+        const service = this.normalizeService(payload.service);
+        const order = await this.prisma.order.create({
+          data: {
+            tenantId,
+            loanId: payload.loanId,
+            service,
+            status: OrderStatus.SUBMITTED,
+            vendorId,
+            metadata: payload.metadata ?? undefined,
+            requestJson: payload.metadata ?? undefined,
+          },
+        });
+
+        await this.prisma.vendorRequest.create({
+          data: {
+            tenantId,
+            orderId: order.id,
+            vendorId,
+            service,
+            status: OrderStatus.SUBMITTED,
+            correlationId: crypto.randomUUID(),
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        this.logger.info({ tenantId, orderId: order.id }, 'Order created');
+        return this.mapOrder(order);
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async bulkCreate(
+    tenantId: string,
+    idempotencyKey: string,
+    payload: OrderBulkRequest,
+  ): Promise<{ accepted: number }> {
+    return await this.tracer.startActiveSpan('orders.bulk', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          return { accepted: 0 };
+        }
+
+        const vendorId = await this.ensureDefaultVendor(tenantId);
+        const orders = await this.prisma.$transaction(
+          payload.loanIds.map((loanId) =>
+            this.prisma.order.create({
+              data: {
+                tenantId,
+                loanId,
+                service: OrderService.FLOOD,
+                status: OrderStatus.SUBMITTED,
+                vendorId,
+              },
+            }),
+          ),
+        );
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        this.logger.info({ tenantId, count: orders.length }, 'Bulk flood orders created');
+        span.setAttribute('app.orders.bulk.count', orders.length);
+        return { accepted: orders.length };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async retryOrder(
+    tenantId: string,
+    idempotencyKey: string,
+    orderId: string,
+  ): Promise<OrderRetryResponse> {
+    return await this.tracer.startActiveSpan('orders.retry', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          return {
+            id: orderId,
+            attempt: 0,
+            scheduledAt: new Date().toISOString(),
+          };
+        }
+
+        const existing = await this.prisma.order.update({
+          where: { id: orderId, tenantId },
+          data: {
+            status: OrderStatus.SUBMITTED,
+            updatedAt: new Date(),
+          },
+        });
+
+        const correlationId = crypto.randomUUID();
+        const vendorId = existing.vendorId ?? (await this.ensureDefaultVendor(tenantId));
+        await this.prisma.vendorRequest.create({
+          data: {
+            tenantId,
+            orderId: existing.id,
+            vendorId,
+            service: existing.service,
+            status: OrderStatus.SUBMITTED,
+            correlationId,
+            attempt: 1,
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        const scheduledAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+        return { id: existing.id, attempt: 1, scheduledAt };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async listDlq(tenantId: string, status?: DlqEntryStatus): Promise<DlqEntryResponse[]> {
+    return await this.tracer.startActiveSpan('dlq.list', async (span) => {
+      try {
+        const entries = await this.prisma.dlqEntry.findMany({
+          where: { tenantId, status: status ?? undefined },
+          orderBy: { firstSeenAt: 'desc' },
+        });
+
+        return entries.map((entry) => ({
+          id: entry.id,
+          source: entry.source,
+          refId: entry.refId,
+          reasonCode: entry.reasonCode,
+          attempts: entry.attempts,
+          status: entry.status,
+          firstSeenAt: entry.firstSeenAt.toISOString(),
+          lastSeenAt: entry.lastSeenAt.toISOString(),
+        }));
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async replayDlq(
+    tenantId: string,
+    idempotencyKey: string,
+    dlqId: string,
+  ): Promise<DlqEntryResponse> {
+    return await this.tracer.startActiveSpan('dlq.replay', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          const entry = await this.prisma.dlqEntry.findUnique({ where: { id: dlqId } });
+          if (!entry) {
+            throw new Error('DLQ entry not found');
+          }
+          return this.mapDlq(entry);
+        }
+
+        const updated = await this.prisma.dlqEntry.update({
+          where: { id: dlqId, tenantId },
+          data: {
+            status: DlqEntryStatus.REPLAYED,
+            replayedAt: new Date(),
+            lastSeenAt: new Date(),
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        this.logger.info({ tenantId, dlqId }, 'DLQ entry replay requested');
+        return this.mapDlq(updated);
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  private mapOrder(order: { [key: string]: any }): OrderResponse {
+    return {
+      id: order.id,
+      loanId: order.loanId,
+      service: this.presentService(order.service),
+      status: order.status,
+      vendorId: order.vendorId,
+      vendorAccountId: order.vendorAccountId,
+      slaDueAt: order.slaDueAt ? order.slaDueAt.toISOString() : null,
+      cost: order.cost ? Number(order.cost) : null,
+      createdAt: order.createdAt.toISOString(),
+      updatedAt: order.updatedAt.toISOString(),
+    };
+  }
+
+  private mapDlq(entry: { [key: string]: any }): DlqEntryResponse {
+    return {
+      id: entry.id,
+      source: entry.source,
+      refId: entry.refId,
+      reasonCode: entry.reasonCode,
+      attempts: entry.attempts,
+      status: entry.status,
+      firstSeenAt: entry.firstSeenAt.toISOString(),
+      lastSeenAt: entry.lastSeenAt.toISOString(),
+    };
+  }
+
+  private hasSeenIdempotencyKey(key: string): boolean {
+    const record = this.idempotencyCache.get(key);
+    if (!record) {
+      return false;
+    }
+
+    if (Date.now() - record.createdAt > 60 * 60 * 1000) {
+      this.idempotencyCache.delete(key);
+      return false;
+    }
+
+    return true;
+  }
+
+  private async ensureDefaultVendor(tenantId: string): Promise<string> {
+    let vendor = await this.prisma.vendor.findFirst({ where: { tenantId } });
+    if (!vendor) {
+      vendor = await this.prisma.vendor.create({
+        data: {
+          tenantId,
+          slug: 'default',
+          name: 'Default Vendor',
+          services: [
+            OrderService.APPRAISAL,
+            OrderService.TITLE,
+            OrderService.FLOOD,
+            OrderService.MI,
+            OrderService.SSA89,
+            OrderService.IRS4506C,
+          ],
+        },
+      });
+    }
+
+    return vendor.id;
+  }
+
+  private normalizeService(service: OrderCreateRequest['service'] | string): OrderService {
+    if (service === '4506-C') {
+      return OrderService.IRS4506C;
+    }
+    const key = service as keyof typeof OrderService;
+    return OrderService[key];
+  }
+
+  private presentService(service: OrderService): OrderResponse['service'] {
+    if (service === OrderService.IRS4506C) {
+      return '4506-C';
+    }
+    return service as OrderResponse['service'];
+  }
+}

--- a/apps/api/src/modules/operations/sla.controller.ts
+++ b/apps/api/src/modules/operations/sla.controller.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, Controller, Get, Query, Req } from '@nestjs/common';
+import { SlaService } from './sla.service.js';
+import { SlaHeatmapResponse } from './dto/sla.dto.js';
+import { FastifyRequest } from 'fastify';
+
+interface TenantRequest extends FastifyRequest {
+  tenant: { tenantId: string };
+}
+
+@Controller('v1/sla')
+export class SlaController {
+  constructor(private readonly slaService: SlaService) {}
+
+  @Get('heatmap')
+  async getHeatmap(
+    @Req() request: TenantRequest,
+    @Query('scope') scope: 'tasks' | 'orders',
+    @Query('range') range: 'week' | 'month' = 'week',
+  ): Promise<SlaHeatmapResponse> {
+    if (!scope) {
+      throw new BadRequestException('scope query parameter is required');
+    }
+    return this.slaService.getHeatmap(request.tenant.tenantId, scope, range);
+  }
+}

--- a/apps/api/src/modules/operations/sla.service.ts
+++ b/apps/api/src/modules/operations/sla.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma.service.js';
+import { trace } from '@opentelemetry/api';
+import { createLogger } from '@haizel/observability';
+import { TaskState } from '@prisma/client';
+import { SlaHeatmapResponse } from './dto/sla.dto.js';
+
+@Injectable()
+export class SlaService {
+  private readonly tracer = trace.getTracer('api.sla');
+  private readonly logger = createLogger('api.sla');
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getHeatmap(
+    tenantId: string,
+    scope: 'tasks' | 'orders',
+    range: 'week' | 'month',
+  ): Promise<SlaHeatmapResponse> {
+    return await this.tracer.startActiveSpan('sla.heatmap', async (span) => {
+      try {
+        const days = range === 'month' ? 30 : 7;
+        const now = new Date();
+        const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+        const buckets = new Map<string, { total: number; warning: number; overdue: number }>();
+
+        if (scope === 'tasks') {
+          const tasks = await this.prisma.task.findMany({
+            where: {
+              tenantId,
+              slaDueAt: { gte: start },
+              NOT: { state: TaskState.DONE },
+            },
+            select: { id: true, slaDueAt: true, state: true },
+          });
+
+          for (const task of tasks) {
+            if (!task.slaDueAt) continue;
+            const bucketKey = this.toBucket(task.slaDueAt);
+            const bucket = buckets.get(bucketKey) ?? { total: 0, warning: 0, overdue: 0 };
+            bucket.total += 1;
+            if (task.slaDueAt.getTime() < now.getTime()) {
+              bucket.overdue += 1;
+            } else if (task.slaDueAt.getTime() - now.getTime() < 24 * 60 * 60 * 1000) {
+              bucket.warning += 1;
+            }
+            buckets.set(bucketKey, bucket);
+          }
+        } else {
+          const orders = await this.prisma.order.findMany({
+            where: {
+              tenantId,
+              slaDueAt: { gte: start },
+            },
+            select: { id: true, slaDueAt: true, status: true },
+          });
+
+          for (const order of orders) {
+            if (!order.slaDueAt) continue;
+            const bucketKey = this.toBucket(order.slaDueAt);
+            const bucket = buckets.get(bucketKey) ?? { total: 0, warning: 0, overdue: 0 };
+            bucket.total += 1;
+            if (order.slaDueAt.getTime() < now.getTime()) {
+              bucket.overdue += 1;
+            } else if (order.slaDueAt.getTime() - now.getTime() < 24 * 60 * 60 * 1000) {
+              bucket.warning += 1;
+            }
+            buckets.set(bucketKey, bucket);
+          }
+        }
+
+        const cells = Array.from(buckets.entries())
+          .sort(([a], [b]) => (a < b ? -1 : 1))
+          .map(([bucket, value]) => ({
+            bucket,
+            total: value.total,
+            warning: value.warning,
+            overdue: value.overdue,
+            query: `scope=${scope}&bucket=${encodeURIComponent(bucket)}`,
+          }));
+
+        this.logger.info({ tenantId, scope, buckets: cells.length }, 'Computed SLA heatmap');
+        return { scope, range, cells, atRisk: cells.filter((cell) => cell.overdue > 0).map((cell) => cell.bucket) };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  private toBucket(input: Date): string {
+    const clone = new Date(input);
+    clone.setMinutes(0, 0, 0);
+    return clone.toISOString();
+  }
+}

--- a/apps/api/src/modules/operations/tasks.controller.ts
+++ b/apps/api/src/modules/operations/tasks.controller.ts
@@ -1,0 +1,96 @@
+import { BadRequestException, Body, Controller, Get, Headers, Param, Post, Query, Req } from '@nestjs/common';
+import { FastifyRequest } from 'fastify';
+import { TasksService } from './tasks.service.js';
+import { TaskState } from '@prisma/client';
+import {
+  QueueListResponse,
+  RouteTaskRequest,
+  RouteTaskResponse,
+  TaskBulkUpdateRequest,
+  TaskListResponse,
+  TaskResponse,
+} from './dto/task.dto.js';
+
+interface TenantRequest extends FastifyRequest {
+  tenant: { tenantId: string };
+}
+
+@Controller('v1')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get('tasks')
+  async listTasks(
+    @Req() request: TenantRequest,
+    @Query('state') state?: string,
+    @Query('queueKey') queueKey?: string,
+    @Query('ownerUserId') ownerUserId?: string,
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '50',
+  ): Promise<TaskListResponse> {
+    const tenantId = request.tenant.tenantId;
+    const filters = {
+      state: state ? (state.toUpperCase() as TaskState) : undefined,
+      queueKey,
+      ownerUserId,
+      page: Number(page),
+      pageSize: Number(pageSize),
+    };
+    return this.tasksService.listTasks(tenantId, filters);
+  }
+
+  @Post('tasks')
+  async bulkUpdate(
+    @Req() request: TenantRequest,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Body() body: TaskBulkUpdateRequest,
+  ): Promise<{ accepted: number }> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.tasksService.bulkUpdate(request.tenant.tenantId, idempotencyKey, body);
+  }
+
+  @Post('tasks/:id/start')
+  async startTask(
+    @Req() request: TenantRequest,
+    @Param('id') id: string,
+  ): Promise<TaskResponse> {
+    return this.tasksService.transitionTask(request.tenant.tenantId, id, TaskState.IN_PROGRESS, undefined);
+  }
+
+  @Post('tasks/:id/block')
+  async blockTask(
+    @Req() request: TenantRequest,
+    @Param('id') id: string,
+    @Body() body: { reason: string; metadata?: Record<string, unknown> },
+  ): Promise<TaskResponse> {
+    const metadata = { ...(body.metadata ?? {}), reason: body.reason };
+    return this.tasksService.transitionTask(request.tenant.tenantId, id, TaskState.BLOCKED, metadata);
+  }
+
+  @Post('tasks/:id/complete')
+  async completeTask(
+    @Req() request: TenantRequest,
+    @Param('id') id: string,
+  ): Promise<TaskResponse> {
+    return this.tasksService.transitionTask(request.tenant.tenantId, id, TaskState.DONE, undefined);
+  }
+
+  @Get('queues')
+  async listQueues(@Req() request: TenantRequest): Promise<QueueListResponse> {
+    return this.tasksService.listQueues(request.tenant.tenantId);
+  }
+
+  @Post('queues/route')
+  async route(
+    @Req() request: TenantRequest,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Body() body: RouteTaskRequest,
+  ): Promise<RouteTaskResponse> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    return this.tasksService.routeTask(request.tenant.tenantId, idempotencyKey, body);
+  }
+}

--- a/apps/api/src/modules/operations/tasks.service.ts
+++ b/apps/api/src/modules/operations/tasks.service.ts
@@ -1,0 +1,279 @@
+import crypto from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma.service.js';
+import { createLogger } from '@haizel/observability';
+import { trace } from '@opentelemetry/api';
+import { TaskState } from '@prisma/client';
+import {
+  QueueDefinitionResponse,
+  QueueListResponse,
+  RouteTaskRequest,
+  RouteTaskResponse,
+  TaskBulkUpdateRequest,
+  TaskListResponse,
+  TaskResponse,
+} from './dto/task.dto.js';
+
+interface TaskFilters {
+  state?: TaskState;
+  queueKey?: string;
+  ownerUserId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+@Injectable()
+export class TasksService {
+  private readonly logger = createLogger('api.tasks');
+  private readonly tracer = trace.getTracer('api.tasks');
+  private readonly idempotencyCache = new Map<string, { createdAt: number }>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listTasks(tenantId: string, filters: TaskFilters = {}): Promise<TaskListResponse> {
+    return await this.tracer.startActiveSpan('tasks.list', async (span) => {
+      try {
+        const page = filters.page ?? 1;
+        const pageSize = filters.pageSize ?? 50;
+        const where = {
+          tenantId,
+          state: filters.state,
+          queueKey: filters.queueKey,
+          ownerUserId: filters.ownerUserId,
+        } satisfies Record<string, unknown>;
+
+        const [total, records] = await this.prisma.$transaction([
+          this.prisma.task.count({ where }),
+          this.prisma.task.findMany({
+            where,
+            orderBy: { dueAt: 'asc' },
+            skip: (page - 1) * pageSize,
+            take: pageSize,
+          }),
+        ]);
+
+        const data: TaskResponse[] = records.map((task) => ({
+          id: task.id,
+          loanId: task.loanId,
+          ownerUserId: task.ownerUserId,
+          queueKey: task.queueKey,
+          type: task.type,
+          state: task.state,
+          priority: task.priority,
+          dueAt: task.dueAt?.toISOString() ?? null,
+          slaDueAt: task.slaDueAt?.toISOString() ?? null,
+          tags: task.tags,
+          metadata: task.metadata as Record<string, unknown> | null,
+          createdAt: task.createdAt.toISOString(),
+          updatedAt: task.updatedAt.toISOString(),
+        }));
+
+        span.setAttributes({ 'app.pagination.total': total, 'app.pagination.page': page });
+        return {
+          data,
+          pagination: {
+            page,
+            pageSize,
+            total,
+          },
+        } satisfies TaskListResponse;
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async bulkUpdate(
+    tenantId: string,
+    idempotencyKey: string,
+    payload: TaskBulkUpdateRequest,
+  ): Promise<{ accepted: number }> {
+    return await this.tracer.startActiveSpan('tasks.bulkUpdate', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          this.logger.info({ idempotencyKey }, 'Duplicate bulk update ignored');
+          return { accepted: 0 };
+        }
+
+        const result = await this.prisma.task.updateMany({
+          where: {
+            tenantId,
+            id: { in: payload.taskIds },
+          },
+          data: {
+            ownerUserId: payload.updates.ownerUserId ?? undefined,
+            dueAt: payload.updates.dueAt ? new Date(payload.updates.dueAt) : undefined,
+            tags: payload.updates.tags ?? undefined,
+            priority: payload.updates.priority ?? undefined,
+            updatedAt: new Date(),
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        this.logger.info({ tenantId, count: result.count }, 'Tasks bulk update scheduled');
+        span.setAttribute('app.tasks.accepted', result.count);
+        return { accepted: result.count };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async transitionTask(
+    tenantId: string,
+    taskId: string,
+    state: TaskState,
+    metadata: Record<string, unknown> | undefined,
+  ): Promise<TaskResponse> {
+    return await this.tracer.startActiveSpan('tasks.transition', async (span) => {
+      try {
+        const existing = await this.prisma.task.findUniqueOrThrow({
+          where: { id: taskId, tenantId },
+        });
+
+        const updated = await this.prisma.task.update({
+          where: { id: taskId, tenantId },
+          data: {
+            state,
+            metadata: metadata ?? undefined,
+            updatedAt: new Date(),
+          },
+        });
+
+        const previousEvent = await this.prisma.taskEvent.findFirst({
+          where: { tenantId, taskId },
+          orderBy: { createdAt: 'desc' },
+        });
+
+        const hash = crypto
+          .createHash('sha256')
+          .update(JSON.stringify({ taskId, from: existing.state, to: state, prev: previousEvent?.hash ?? null, metadata }))
+          .digest('hex');
+
+        await this.prisma.taskEvent.create({
+          data: {
+            tenantId,
+            taskId,
+            eventType: 'state.transition',
+            stateFrom: existing.state,
+            stateTo: state,
+            payload: metadata,
+            prevHash: previousEvent?.hash ?? null,
+            hash,
+          },
+        });
+
+        return {
+          id: updated.id,
+          loanId: updated.loanId,
+          ownerUserId: updated.ownerUserId,
+          queueKey: updated.queueKey,
+          type: updated.type,
+          state: updated.state,
+          priority: updated.priority,
+          dueAt: updated.dueAt?.toISOString() ?? null,
+          slaDueAt: updated.slaDueAt?.toISOString() ?? null,
+          tags: updated.tags,
+          metadata: updated.metadata as Record<string, unknown> | null,
+          createdAt: updated.createdAt.toISOString(),
+          updatedAt: updated.updatedAt.toISOString(),
+        };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async listQueues(tenantId: string): Promise<QueueListResponse> {
+    return await this.tracer.startActiveSpan('queues.list', async (span) => {
+      try {
+        const queues = await this.prisma.queueDef.findMany({ where: { tenantId } });
+        const tasks = await this.prisma.task.findMany({
+          where: { tenantId },
+          select: { id: true, queueKey: true, state: true, slaDueAt: true },
+        });
+
+        const aggregates = new Map<string, QueueDefinitionResponse>();
+        for (const queue of queues) {
+          aggregates.set(queue.key, {
+            key: queue.key,
+            name: queue.name,
+            skills: queue.skills,
+            routing: queue.routingJson as Record<string, unknown>,
+            aggregates: {
+              total: 0,
+              new: 0,
+              inProgress: 0,
+              blocked: 0,
+              overdue: 0,
+            },
+          });
+        }
+
+        const now = Date.now();
+        for (const task of tasks) {
+          const bucket = aggregates.get(task.queueKey);
+          if (!bucket) continue;
+          bucket.aggregates.total += 1;
+          if (task.state === 'NEW') bucket.aggregates.new += 1;
+          if (task.state === 'IN_PROGRESS') bucket.aggregates.inProgress += 1;
+          if (task.state === 'BLOCKED') bucket.aggregates.blocked += 1;
+          if (task.slaDueAt && task.slaDueAt.getTime() < now) {
+            bucket.aggregates.overdue += 1;
+          }
+        }
+
+        span.setAttribute('app.queues.count', aggregates.size);
+        return { data: Array.from(aggregates.values()), updatedAt: new Date().toISOString() };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  async routeTask(
+    tenantId: string,
+    idempotencyKey: string,
+    payload: RouteTaskRequest,
+  ): Promise<RouteTaskResponse> {
+    return await this.tracer.startActiveSpan('tasks.route', async (span) => {
+      try {
+        if (this.hasSeenIdempotencyKey(idempotencyKey)) {
+          const existing = await this.prisma.task.findUnique({ where: { id: payload.taskId } });
+          if (existing) {
+            return { queueKey: existing.queueKey, ownerUserId: existing.ownerUserId };
+          }
+        }
+
+        const task = await this.prisma.task.update({
+          where: { id: payload.taskId, tenantId },
+          data: {
+            queueKey: payload.preferredQueues?.[0] ?? 'default',
+            ownerUserId: null,
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now() });
+        this.logger.info({ tenantId, taskId: task.id, queueKey: task.queueKey }, 'Task routed');
+        return { queueKey: task.queueKey, ownerUserId: task.ownerUserId };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  private hasSeenIdempotencyKey(key: string): boolean {
+    const record = this.idempotencyCache.get(key);
+    if (!record) {
+      return false;
+    }
+
+    // expire keys after one hour
+    if (Date.now() - record.createdAt > 1000 * 60 * 60) {
+      this.idempotencyCache.delete(key);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/operations/webhooks.controller.ts
+++ b/apps/api/src/modules/operations/webhooks.controller.ts
@@ -1,0 +1,35 @@
+import { BadRequestException, Body, Controller, Headers, Param, Post, Req } from '@nestjs/common';
+import { WebhooksService } from './webhooks.service.js';
+import { FastifyRequest } from 'fastify';
+
+interface TenantRequest extends FastifyRequest {
+  tenant: { tenantId: string };
+}
+
+@Controller('v1/webhooks')
+export class WebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Post(':vendor')
+  async ingest(
+    @Req() request: TenantRequest,
+    @Param('vendor') vendor: string,
+    @Headers('idempotency-key') idempotencyKey: string,
+    @Headers('x-signature') signature: string,
+    @Body() body: Record<string, unknown>,
+  ): Promise<{ id: string; signatureValid: boolean }> {
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    if (!signature) {
+      throw new BadRequestException('X-Signature header is required');
+    }
+
+    const headers = Object.entries(request.headers).reduce<Record<string, string>>((acc, [key, value]) => {
+      acc[key] = Array.isArray(value) ? value.join(',') : String(value);
+      return acc;
+    }, {});
+
+    return this.webhooksService.ingest(request.tenant.tenantId, vendor, idempotencyKey, signature, body, headers);
+  }
+}

--- a/apps/api/src/modules/operations/webhooks.service.ts
+++ b/apps/api/src/modules/operations/webhooks.service.ts
@@ -1,0 +1,86 @@
+import crypto from 'node:crypto';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma.service.js';
+import { createLogger } from '@haizel/observability';
+import { trace } from '@opentelemetry/api';
+
+interface WebhookIngestResponse {
+  id: string;
+  signatureValid: boolean;
+}
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = createLogger('api.webhooks');
+  private readonly tracer = trace.getTracer('api.webhooks');
+  private readonly idempotencyCache = new Map<string, { createdAt: number; webhookId: string }>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async ingest(
+    tenantId: string,
+    vendorSlug: string,
+    idempotencyKey: string,
+    signature: string,
+    payload: Record<string, unknown>,
+    headers: Record<string, string>,
+  ): Promise<WebhookIngestResponse> {
+    return await this.tracer.startActiveSpan('webhooks.ingest', async (span) => {
+      try {
+        const cached = this.idempotencyCache.get(idempotencyKey);
+        if (cached) {
+          return { id: cached.webhookId, signatureValid: true };
+        }
+
+        const vendor = await this.prisma.vendor.findFirst({
+          where: {
+            OR: [{ tenantId, slug: vendorSlug }, { tenantId: null, slug: vendorSlug }],
+          },
+        });
+
+        if (!vendor) {
+          throw new NotFoundException('Vendor not found');
+        }
+
+        const expectedSignature = this.calculateSignature(vendor.id, payload);
+        if (!signature) {
+          throw new BadRequestException('Missing signature header');
+        }
+
+        const signatureValid = this.safeCompare(signature, expectedSignature);
+
+        const webhook = await this.prisma.webhook.create({
+          data: {
+            tenantId,
+            vendorId: vendor.id,
+            signature,
+            signatureValid,
+            payloadJson: payload,
+            headersJson: headers,
+            status: 'received',
+          },
+        });
+
+        this.idempotencyCache.set(idempotencyKey, { createdAt: Date.now(), webhookId: webhook.id });
+        this.logger.info({ tenantId, vendor: vendor.slug, webhookId: webhook.id, signatureValid }, 'Webhook ingested');
+        return { id: webhook.id, signatureValid };
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  private calculateSignature(vendorId: string, payload: Record<string, unknown>): string {
+    return crypto.createHmac('sha256', vendorId).update(JSON.stringify(payload)).digest('hex');
+  }
+
+  private safeCompare(a: string, b: string): boolean {
+    const aBuffer = Buffer.from(a);
+    const bBuffer = Buffer.from(b);
+    if (aBuffer.length !== bBuffer.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(aBuffer, bBuffer);
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@haizel/observability": "workspace:*",
     "@haizel/types": "workspace:*",
     "@opentelemetry/api": "1.8.0",
+    "@tanstack/react-query": "5.28.6",
     "axios": "1.6.8",
     "jose": "5.2.2",
     "next": "14.1.0",

--- a/apps/web/src/app/(dashboard)/orders/page.tsx
+++ b/apps/web/src/app/(dashboard)/orders/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface OrderCard {
+  id: string;
+  loanId: string;
+  service: 'APPRAISAL' | 'TITLE' | 'FLOOD' | 'MI' | 'SSA89' | '4506-C';
+  status: 'DRAFT' | 'SUBMITTED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+  vendor: string;
+  slaDueAt?: string | null;
+}
+
+interface VendorHealthMetric {
+  vendor: string;
+  latencyMs: number;
+  failureRate: number;
+  status: 'healthy' | 'degraded' | 'down';
+}
+
+interface OrdersDashboardData {
+  orders: OrderCard[];
+  vendorHealth: VendorHealthMetric[];
+}
+
+const demoOrders: OrdersDashboardData = {
+  orders: [
+    {
+      id: 'order-1',
+      loanId: 'LN-10234',
+      service: 'FLOOD',
+      status: 'SUBMITTED',
+      vendor: 'CoreLogic Flood',
+      slaDueAt: new Date(Date.now() + 12 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 'order-2',
+      loanId: 'LN-19822',
+      service: 'TITLE',
+      status: 'IN_PROGRESS',
+      vendor: 'First American Title',
+      slaDueAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 'order-3',
+      loanId: 'LN-20931',
+      service: 'SSA89',
+      status: 'FAILED',
+      vendor: 'SSA Gateway',
+      slaDueAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 'order-4',
+      loanId: 'LN-18002',
+      service: 'APPRAISAL',
+      status: 'COMPLETED',
+      vendor: 'Mercury Network',
+      slaDueAt: new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString(),
+    },
+  ],
+  vendorHealth: [
+    { vendor: 'CoreLogic Flood', latencyMs: 5200, failureRate: 0.02, status: 'healthy' },
+    { vendor: 'SSA Gateway', latencyMs: 8200, failureRate: 0.11, status: 'degraded' },
+    { vendor: 'First American Title', latencyMs: 4600, failureRate: 0.04, status: 'healthy' },
+  ],
+};
+
+export default function OrdersPage() {
+  const [viewStatus, setViewStatus] = useState<
+    'SUBMITTED' | 'IN_PROGRESS' | 'FAILED' | 'COMPLETED'
+  >('SUBMITTED');
+  const { data } = useQuery<OrdersDashboardData>({
+    queryKey: ['orders-dashboard', viewStatus],
+    queryFn: async () => demoOrders,
+    staleTime: 30_000,
+  });
+
+  const statuses: Array<{
+    key: 'SUBMITTED' | 'IN_PROGRESS' | 'FAILED' | 'COMPLETED';
+    label: string;
+  }> = [
+    { key: 'SUBMITTED', label: 'Submitted' },
+    { key: 'IN_PROGRESS', label: 'In Progress' },
+    { key: 'FAILED', label: 'Failed' },
+    { key: 'COMPLETED', label: 'Completed' },
+  ];
+
+  const grouped = statuses.map((column) => ({
+    column,
+    orders: (data?.orders ?? []).filter((order) => order.status === column.key),
+  }));
+
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Orders Hub</h1>
+          <p className="text-sm text-slate-400">Track vendor pipeline, SLA performance, and retry workflows.</p>
+        </div>
+        <div className="flex gap-2 rounded border border-slate-700 p-1">
+          {statuses.map((status) => (
+            <button
+              key={status.key}
+              onClick={() => setViewStatus(status.key)}
+              className={`rounded px-3 py-1 text-sm font-medium transition ${
+                viewStatus === status.key ? 'bg-indigo-500 text-white' : 'text-slate-300 hover:bg-slate-800'
+              }`}
+            >
+              {status.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-[3fr_1fr]">
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner">
+          <h2 className="text-lg font-semibold text-slate-100">Orders Board</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {grouped.map(({ column, orders }) => (
+              <div key={column.key} className="rounded border border-slate-800 bg-slate-900/40 p-3">
+                <div className="mb-3 flex items-center justify-between text-sm font-semibold text-slate-200">
+                  <span>{column.label}</span>
+                  <span className="text-xs text-slate-400">{orders.length}</span>
+                </div>
+                <div className="space-y-3">
+                  {orders.length === 0 && (
+                    <p className="text-xs text-slate-500">No orders in this stage.</p>
+                  )}
+                  {orders.map((order) => (
+                    <article key={order.id} className="space-y-2 rounded border border-slate-800 bg-slate-950/60 p-3 text-xs">
+                      <div className="flex items-center justify-between text-slate-200">
+                        <span className="font-semibold">{order.loanId}</span>
+                        <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] uppercase tracking-wide text-slate-300">
+                          {order.service}
+                        </span>
+                      </div>
+                      <div className="text-slate-400">Vendor: {order.vendor}</div>
+                      <SlaBadge sla={order.slaDueAt} />
+                      <button className="w-full rounded border border-indigo-500/60 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-200 hover:bg-indigo-500/20">
+                        View Timeline
+                      </button>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <aside className="space-y-4">
+          <VendorHealthPanel vendorHealth={data?.vendorHealth ?? []} />
+          <RetryPanel />
+        </aside>
+      </section>
+    </main>
+  );
+}
+
+function VendorHealthPanel({ vendorHealth }: { vendorHealth: VendorHealthMetric[] }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Vendor Health</h3>
+      <div className="mt-3 space-y-3">
+        {vendorHealth.map((metric) => (
+          <div key={metric.vendor} className="rounded border border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-300">
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-slate-100">{metric.vendor}</span>
+              <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${healthTone(metric.status)}`}>
+                {metric.status}
+              </span>
+            </div>
+            <div className="mt-2 flex items-center justify-between">
+              <span>Latency</span>
+              <span className="font-mono">{Math.round(metric.latencyMs / 100) / 10}s</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Failure</span>
+              <span className="font-mono">{(metric.failureRate * 100).toFixed(1)}%</span>
+            </div>
+            <button className="mt-3 w-full rounded border border-slate-700 px-2 py-1 text-[10px] uppercase tracking-wide text-slate-200 hover:bg-slate-800">
+              Reroute
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RetryPanel() {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner text-sm text-slate-300">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Retries &amp; DLQ</h3>
+      <p className="mt-2 text-xs text-slate-400">
+        Monitor retry budgets and move exhausted attempts into the DLQ. Use the replay control below once a
+        vendor is healthy.
+      </p>
+      <div className="mt-3 space-y-2 text-xs">
+        <div className="flex items-center justify-between">
+          <span>Active Retries</span>
+          <span className="font-mono">3</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>DLQ Items</span>
+          <span className="font-mono text-rose-200">1</span>
+        </div>
+      </div>
+      <button className="mt-4 w-full rounded border border-emerald-500/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200 hover:bg-emerald-500/20">
+        Replay DLQ
+      </button>
+    </div>
+  );
+}
+
+function SlaBadge({ sla }: { sla?: string | null }) {
+  if (!sla) {
+    return <span className="text-[10px] text-slate-400">No SLA</span>;
+  }
+  const due = new Date(sla);
+  const remaining = due.getTime() - Date.now();
+  const tone = remaining < 0 ? 'bg-rose-900/40 text-rose-200' : remaining < 6 * 60 * 60 * 1000 ? 'bg-amber-900/40 text-amber-200' : 'bg-emerald-900/40 text-emerald-200';
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${tone}`}>
+      SLA {remaining < 0 ? 'Overdue' : `${Math.ceil(remaining / (60 * 60 * 1000))}h`}
+    </span>
+  );
+}
+
+function healthTone(status: VendorHealthMetric['status']) {
+  switch (status) {
+    case 'healthy':
+      return 'bg-emerald-900/40 text-emerald-200';
+    case 'degraded':
+      return 'bg-amber-900/40 text-amber-200';
+    case 'down':
+      return 'bg-rose-900/40 text-rose-200';
+  }
+}

--- a/apps/web/src/app/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/(dashboard)/tasks/page.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface TaskRecord {
+  id: string;
+  title: string;
+  queueKey: string;
+  state: 'NEW' | 'IN_PROGRESS' | 'BLOCKED' | 'DONE';
+  priority: number;
+  dueAt?: string | null;
+  slaDueAt?: string | null;
+  ownerUserId?: string | null;
+  tags: string[];
+}
+
+interface QueueAggregate {
+  key: string;
+  name: string;
+  aggregates: {
+    total: number;
+    new: number;
+    inProgress: number;
+    blocked: number;
+    overdue: number;
+  };
+}
+
+interface HeatmapCell {
+  bucket: string;
+  total: number;
+  warning: number;
+  overdue: number;
+}
+
+interface TaskDashboardData {
+  personal: TaskRecord[];
+  team: TaskRecord[];
+  queues: QueueAggregate[];
+  heatmap: HeatmapCell[];
+}
+
+const demoData: TaskDashboardData = {
+  personal: [
+    {
+      id: 'task-1',
+      title: 'Collect updated insurance binder',
+      queueKey: 'processor-personal',
+      state: 'IN_PROGRESS',
+      priority: 2,
+      dueAt: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+      slaDueAt: new Date(Date.now() + 18 * 60 * 60 * 1000).toISOString(),
+      ownerUserId: 'user-1',
+      tags: ['Insurance', 'Follow-up'],
+    },
+    {
+      id: 'task-2',
+      title: 'Verify SSA-89 signature',
+      queueKey: 'processor-personal',
+      state: 'NEW',
+      priority: 1,
+      dueAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      slaDueAt: new Date(Date.now() + 12 * 60 * 60 * 1000).toISOString(),
+      ownerUserId: 'user-1',
+      tags: ['SSA-89'],
+    },
+  ],
+  team: [
+    {
+      id: 'task-3',
+      title: 'Order flood certificate',
+      queueKey: 'team-flood',
+      state: 'BLOCKED',
+      priority: 3,
+      dueAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      slaDueAt: new Date(Date.now() + 36 * 60 * 60 * 1000).toISOString(),
+      ownerUserId: null,
+      tags: ['Flood', 'Orders'],
+    },
+    {
+      id: 'task-4',
+      title: 'Review appraisal variance',
+      queueKey: 'team-appraisal',
+      state: 'NEW',
+      priority: 2,
+      dueAt: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+      slaDueAt: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+      ownerUserId: null,
+      tags: ['Appraisal'],
+    },
+  ],
+  queues: [
+    {
+      key: 'processor-personal',
+      name: 'My Work',
+      aggregates: { total: 12, new: 3, inProgress: 6, blocked: 1, overdue: 2 },
+    },
+    {
+      key: 'team-flood',
+      name: 'Flood Queue',
+      aggregates: { total: 34, new: 12, inProgress: 18, blocked: 4, overdue: 6 },
+    },
+  ],
+  heatmap: Array.from({ length: 7 }).map((_, index) => {
+    const date = new Date();
+    date.setDate(date.getDate() - (6 - index));
+    date.setHours(9, 0, 0, 0);
+    const overdue = index % 3 === 0 ? 2 : 0;
+    const warning = index % 2 === 0 ? 3 : 1;
+    const total = 6 + index;
+    return {
+      bucket: date.toISOString(),
+      total,
+      warning,
+      overdue,
+    } satisfies HeatmapCell;
+  }),
+};
+
+export default function TasksPage() {
+  const [view, setView] = useState<'personal' | 'team'>('personal');
+  const { data } = useQuery<TaskDashboardData>({
+    queryKey: ['tasks-dashboard', view],
+    queryFn: async () => demoData,
+    staleTime: 30_000,
+  });
+
+  const tasks = useMemo(() => {
+    if (!data) return [];
+    return view === 'personal' ? data.personal : data.team;
+  }, [data, view]);
+
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-100">Tasks &amp; Queues</h1>
+          <p className="text-sm text-slate-400">Monitor personal and team workloads with live SLA signals.</p>
+        </div>
+        <div className="flex gap-2 rounded border border-slate-700 p-1">
+          {(
+            [
+              { key: 'personal', label: 'My Tasks' },
+              { key: 'team', label: 'Team Queues' },
+            ] as const
+          ).map((option) => (
+            <button
+              key={option.key}
+              onClick={() => setView(option.key)}
+              className={`rounded px-3 py-1 text-sm font-medium transition ${
+                view === option.key ? 'bg-indigo-500 text-white' : 'text-slate-300 hover:bg-slate-800'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-slate-100">Open Tasks</h2>
+            <span className="text-xs text-slate-400">Showing {tasks.length} items</span>
+          </div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-800 text-sm">
+              <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-3 py-2">Title</th>
+                  <th className="px-3 py-2">Queue</th>
+                  <th className="px-3 py-2">State</th>
+                  <th className="px-3 py-2">Due</th>
+                  <th className="px-3 py-2">SLA</th>
+                  <th className="px-3 py-2">Tags</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800 text-slate-200">
+                {tasks.map((task) => (
+                  <tr key={task.id} className="hover:bg-slate-900/40">
+                    <td className="px-3 py-2 font-medium">{task.title}</td>
+                    <td className="px-3 py-2 text-slate-400">{task.queueKey}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`rounded-full px-2 py-1 text-xs font-semibold ${stateColor(task.state)}`}
+                      >
+                        {task.state.replace('_', ' ')}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-slate-300">{formatDate(task.dueAt)}</td>
+                    <td className="px-3 py-2">{renderSlaChip(task.slaDueAt)}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-wrap gap-1">
+                        {task.tags.map((tag) => (
+                          <span key={tag} className="rounded-full bg-slate-800 px-2 py-0.5 text-xs text-slate-300">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <aside className="space-y-4">
+          <QueueOverview queues={data?.queues ?? []} />
+          <Heatmap heatmap={data?.heatmap ?? []} />
+        </aside>
+      </section>
+    </main>
+  );
+}
+
+function QueueOverview({ queues }: { queues: QueueAggregate[] }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Queue Health</h3>
+      <div className="mt-3 space-y-3">
+        {queues.map((queue) => (
+          <div key={queue.key} className="rounded border border-slate-800 bg-slate-900/50 p-3">
+            <div className="flex items-center justify-between text-sm text-slate-200">
+              <span className="font-medium">{queue.name}</span>
+              <span className="text-xs text-slate-400">{queue.aggregates.total} open</span>
+            </div>
+            <div className="mt-2 grid grid-cols-4 gap-2 text-xs text-slate-400">
+              <Metric label="New" value={queue.aggregates.new} />
+              <Metric label="In Progress" value={queue.aggregates.inProgress} />
+              <Metric label="Blocked" value={queue.aggregates.blocked} />
+              <Metric label="Overdue" value={queue.aggregates.overdue} highlight />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Heatmap({ heatmap }: { heatmap: HeatmapCell[] }) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-4 shadow-inner">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">SLA Heatmap</h3>
+      <div className="mt-3 grid grid-cols-7 gap-1">
+        {heatmap.map((cell) => (
+          <div
+            key={cell.bucket}
+            className={`flex h-16 flex-col justify-between rounded p-2 text-xs ${heatmapClass(cell)}`}
+            title={`${cell.total} tasks`}
+          >
+            <span className="font-semibold text-slate-100">{new Date(cell.bucket).getDate()}</span>
+            <div className="flex items-center justify-between text-[10px] text-slate-200">
+              <span>⚠️ {cell.warning}</span>
+              <span>⏰ {cell.overdue}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value, highlight }: { label: string; value: number; highlight?: boolean }) {
+  return (
+    <div className={`rounded px-2 py-1 text-center ${highlight ? 'bg-rose-900/40 text-rose-200' : 'bg-slate-900/50 text-slate-300'}`}>
+      <div className="text-sm font-semibold">{value}</div>
+      <div className="text-[10px] uppercase tracking-wide">{label}</div>
+    </div>
+  );
+}
+
+function heatmapClass(cell: HeatmapCell) {
+  if (cell.overdue > 0) {
+    return 'bg-rose-900/50 border border-rose-500/60';
+  }
+  if (cell.warning > 2) {
+    return 'bg-amber-900/40 border border-amber-500/60';
+  }
+  return 'bg-emerald-900/30 border border-emerald-500/40';
+}
+
+function stateColor(state: TaskRecord['state']) {
+  switch (state) {
+    case 'NEW':
+      return 'bg-blue-900/50 text-blue-200';
+    case 'IN_PROGRESS':
+      return 'bg-emerald-900/50 text-emerald-200';
+    case 'BLOCKED':
+      return 'bg-amber-900/60 text-amber-100';
+    case 'DONE':
+      return 'bg-slate-800 text-slate-300';
+  }
+}
+
+function formatDate(input?: string | null) {
+  if (!input) return '—';
+  const date = new Date(input);
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }).format(
+    date,
+  );
+}
+
+function renderSlaChip(sla?: string | null) {
+  if (!sla) {
+    return <span className="text-xs text-slate-400">Not set</span>;
+  }
+  const due = new Date(sla);
+  const remaining = due.getTime() - Date.now();
+  const hours = Math.round(remaining / (60 * 60 * 1000));
+  const status = remaining < 0 ? 'Overdue' : hours < 12 ? 'At Risk' : 'On Track';
+  const tone = remaining < 0 ? 'bg-rose-900/40 text-rose-200' : hours < 12 ? 'bg-amber-900/40 text-amber-200' : 'bg-emerald-900/40 text-emerald-200';
+  return (
+    <span className={`rounded-full px-2 py-1 text-xs font-semibold ${tone}`}>
+      {status} · {formatDate(sla)}
+    </span>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import { ThemeProvider } from '../lib/theme';
+import { QueryProvider } from '../lib/query-provider';
 
 export const metadata = {
   title: 'Haizel Broker Platform',
@@ -10,7 +11,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <QueryProvider>{children}</QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/lib/query-provider.tsx
+++ b/apps/web/src/lib/query-provider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/apps/worker/src/activities/index.ts
+++ b/apps/worker/src/activities/index.ts
@@ -5,3 +5,35 @@ const logger = createLogger('worker.activities');
 export async function emitLoanCreated(loanId: string) {
   logger.info({ loanId, event: 'loan.created.workflow' }, 'Emitting workflow event');
 }
+
+export async function routeTaskActivity(input: { tenantId: string; taskId: string; skills?: string[] }) {
+  logger.info({ ...input, activity: 'RouteTask' }, 'Routing task via Temporal activity');
+}
+
+export async function computeSlaActivity(input: { tenantId: string; scope: 'tasks' | 'orders' }) {
+  logger.info({ ...input, activity: 'ComputeSla' }, 'Computing SLA heatmap snapshot');
+}
+
+export async function submitOrderActivity(input: { tenantId: string; orderId: string; vendorId: string }) {
+  logger.info({ ...input, activity: 'SubmitOrder' }, 'Submitting order to vendor');
+}
+
+export async function pollVendorStatusActivity(input: { tenantId: string; vendorRequestId: string }) {
+  logger.info({ ...input, activity: 'PollVendorStatus' }, 'Polling vendor status');
+}
+
+export async function handleWebhookActivity(input: { tenantId: string; webhookId: string }) {
+  logger.info({ ...input, activity: 'HandleWebhook' }, 'Handling webhook payload');
+}
+
+export async function retryWithBackoffActivity(input: { tenantId: string; referenceId: string; attempt: number }) {
+  logger.info({ ...input, activity: 'RetryWithBackoff' }, 'Scheduling retry with backoff');
+}
+
+export async function moveToDlqActivity(input: { tenantId?: string | null; source: string; refId?: string | null }) {
+  logger.warn({ ...input, activity: 'MoveToDLQ' }, 'Moving message to DLQ');
+}
+
+export async function replayFromDlqActivity(input: { tenantId?: string | null; dlqId: string }) {
+  logger.info({ ...input, activity: 'ReplayFromDLQ' }, 'Replaying DLQ entry');
+}

--- a/apps/worker/src/workflows/operations.workflow.ts
+++ b/apps/worker/src/workflows/operations.workflow.ts
@@ -1,0 +1,56 @@
+import { proxyActivities } from '@temporalio/workflow';
+
+const activities = proxyActivities({
+  startToCloseTimeout: '2 minutes',
+});
+
+type Activities = {
+  routeTaskActivity: (input: { tenantId: string; taskId: string; skills?: string[] }) => Promise<void>;
+  computeSlaActivity: (input: { tenantId: string; scope: 'tasks' | 'orders' }) => Promise<void>;
+  submitOrderActivity: (input: { tenantId: string; orderId: string; vendorId: string }) => Promise<void>;
+  pollVendorStatusActivity: (input: { tenantId: string; vendorRequestId: string }) => Promise<void>;
+  handleWebhookActivity: (input: { tenantId: string; webhookId: string }) => Promise<void>;
+  retryWithBackoffActivity: (input: { tenantId: string; referenceId: string; attempt: number }) => Promise<void>;
+  moveToDlqActivity: (input: { tenantId?: string | null; source: string; refId?: string | null }) => Promise<void>;
+  replayFromDlqActivity: (input: { tenantId?: string | null; dlqId: string }) => Promise<void>;
+};
+
+const {
+  routeTaskActivity,
+  computeSlaActivity,
+  submitOrderActivity,
+  pollVendorStatusActivity,
+  handleWebhookActivity,
+  retryWithBackoffActivity,
+  moveToDlqActivity,
+  replayFromDlqActivity,
+} = activities as Activities;
+
+export async function TaskRoutingWorkflow(input: { tenantId: string; taskId: string; skills?: string[] }) {
+  await routeTaskActivity(input);
+}
+
+export async function SlaAggregationWorkflow(input: { tenantId: string; scope: 'tasks' | 'orders' }) {
+  await computeSlaActivity(input);
+}
+
+export async function OrderSubmissionWorkflow(input: { tenantId: string; orderId: string; vendorId: string }) {
+  await submitOrderActivity(input);
+  await retryWithBackoffActivity({ tenantId: input.tenantId, referenceId: input.orderId, attempt: 1 });
+}
+
+export async function VendorRecoveryWorkflow(input: { tenantId: string; vendorRequestId: string }) {
+  await pollVendorStatusActivity(input);
+}
+
+export async function WebhookProcessingWorkflow(input: { tenantId: string; webhookId: string }) {
+  await handleWebhookActivity(input);
+}
+
+export async function DlqWorkflow(input: { tenantId?: string | null; dlqId: string; source: string }) {
+  await moveToDlqActivity({ tenantId: input.tenantId, source: input.source, refId: input.dlqId });
+}
+
+export async function DlqReplayWorkflow(input: { tenantId?: string | null; dlqId: string }) {
+  await replayFromDlqActivity(input);
+}

--- a/docs/architecture/m6-openapi.yaml
+++ b/docs/architecture/m6-openapi.yaml
@@ -1,0 +1,697 @@
+openapi: 3.1.0
+info:
+  title: Haizel Tasks, Queues, and Orders API
+  version: 0.6.0
+  description: |
+    Milestone M6 contract for task management, SLA heatmaps, orders, and DLQ operations.
+servers:
+  - url: https://api.haizel.dev/v1
+    description: Production
+  - url: https://api.sandbox.haizel.dev/v1
+    description: Sandbox
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    TenantId:
+      in: header
+      name: X-Tenant-Id
+      schema:
+        type: string
+      required: true
+      description: Tenant context for multi-tenancy.
+  schemas:
+    Task:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        loanId:
+          type: string
+          format: uuid
+          nullable: true
+        ownerUserId:
+          type: string
+          format: uuid
+          nullable: true
+        queueKey:
+          type: string
+        type:
+          type: string
+        state:
+          type: string
+          enum: [NEW, IN_PROGRESS, BLOCKED, DONE]
+        priority:
+          type: integer
+          minimum: 1
+        dueAt:
+          type: string
+          format: date-time
+          nullable: true
+        slaDueAt:
+          type: string
+          format: date-time
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - queueKey
+        - type
+        - state
+        - priority
+        - createdAt
+        - updatedAt
+    QueueDefinition:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        skills:
+          type: array
+          items:
+            type: string
+        routing:
+          type: object
+          additionalProperties: true
+        aggregates:
+          type: object
+          properties:
+            total:
+              type: integer
+            new:
+              type: integer
+            inProgress:
+              type: integer
+            blocked:
+              type: integer
+            overdue:
+              type: integer
+      required:
+        - key
+        - name
+        - skills
+        - routing
+    SlaHeatmapCell:
+      type: object
+      properties:
+        bucket:
+          type: string
+          description: ISO timestamp bucket for the cell.
+        total:
+          type: integer
+        warning:
+          type: integer
+        overdue:
+          type: integer
+        query:
+          type: string
+          description: Relative link for filtered list view.
+      required:
+        - bucket
+        - total
+    SlaHeatmap:
+      type: object
+      properties:
+        scope:
+          type: string
+          enum: [tasks, orders]
+        range:
+          type: string
+          enum: [week, month]
+        cells:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlaHeatmapCell'
+        atRisk:
+          type: array
+          description: List of ids at risk or overdue.
+          items:
+            type: string
+      required:
+        - scope
+        - range
+        - cells
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        loanId:
+          type: string
+          format: uuid
+          nullable: true
+        service:
+          type: string
+          enum: [APPRAISAL, TITLE, FLOOD, MI, SSA89, '4506-C']
+        status:
+          type: string
+          enum: [DRAFT, SUBMITTED, IN_PROGRESS, COMPLETED, FAILED, CANCELED]
+        vendorId:
+          type: string
+          format: uuid
+          nullable: true
+        vendorAccountId:
+          type: string
+          format: uuid
+          nullable: true
+        slaDueAt:
+          type: string
+          format: date-time
+          nullable: true
+        cost:
+          type: number
+          format: float
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - service
+        - status
+        - createdAt
+        - updatedAt
+    DlqEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        source:
+          type: string
+        refId:
+          type: string
+          nullable: true
+        reasonCode:
+          type: string
+        attempts:
+          type: integer
+        status:
+          type: string
+          enum: [PENDING, REPLAYED, ARCHIVED]
+        firstSeenAt:
+          type: string
+          format: date-time
+        lastSeenAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - source
+        - reasonCode
+        - attempts
+        - status
+        - firstSeenAt
+        - lastSeenAt
+security:
+  - BearerAuth: []
+paths:
+  /tasks:
+    get:
+      summary: List tasks for the current tenant
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: query
+          name: state
+          schema:
+            type: string
+          description: Optional task state filter.
+        - in: query
+          name: queueKey
+          schema:
+            type: string
+        - in: query
+          name: ownerUserId
+          schema:
+            type: string
+            format: uuid
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: Paginated task response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Task'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                      total:
+                        type: integer
+                required:
+                  - data
+                  - pagination
+    post:
+      summary: Bulk update tasks
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                taskIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                updates:
+                  type: object
+                  properties:
+                    ownerUserId:
+                      type: string
+                      format: uuid
+                      nullable: true
+                    dueAt:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                    priority:
+                      type: integer
+              required:
+                - taskIds
+                - updates
+      responses:
+        '202':
+          description: Tasks queued for update
+  /tasks/{id}/start:
+    post:
+      summary: Start work on a task
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Updated task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /tasks/{id}/block:
+    post:
+      summary: Block a task with reason metadata
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+              required:
+                - reason
+      responses:
+        '200':
+          description: Blocked task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /tasks/{id}/complete:
+    post:
+      summary: Complete a task
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Completed task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /queues:
+    get:
+      summary: Retrieve configured queues and aggregates
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+      responses:
+        '200':
+          description: Queue catalog with aggregates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/QueueDefinition'
+                  updatedAt:
+                    type: string
+                    format: date-time
+                required:
+                  - data
+                  - updatedAt
+  /queues/route:
+    post:
+      summary: Route a task according to queue rules
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                taskId:
+                  type: string
+                  format: uuid
+                preferredQueues:
+                  type: array
+                  items:
+                    type: string
+                skills:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - taskId
+      responses:
+        '200':
+          description: Routed task metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  queueKey:
+                    type: string
+                  ownerUserId:
+                    type: string
+                    format: uuid
+                    nullable: true
+  /sla/heatmap:
+    get:
+      summary: SLA heatmap aggregates
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: query
+          name: scope
+          required: true
+          schema:
+            type: string
+            enum: [tasks, orders]
+        - in: query
+          name: range
+          schema:
+            type: string
+            enum: [week, month]
+            default: week
+      responses:
+        '200':
+          description: Heatmap payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SlaHeatmap'
+  /orders:
+    get:
+      summary: List orders
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: query
+          name: service
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            type: string
+        - in: query
+          name: loanId
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Orders list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Order'
+                  total:
+                    type: integer
+                required:
+                  - data
+                  - total
+    post:
+      summary: Create order
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                loanId:
+                  type: string
+                  format: uuid
+                service:
+                  type: string
+                  enum: [APPRAISAL, TITLE, FLOOD, MI, SSA89, '4506-C']
+                vendorId:
+                  type: string
+                  format: uuid
+                  nullable: true
+                metadata:
+                  type: object
+                  additionalProperties: true
+              required:
+                - loanId
+                - service
+      responses:
+        '201':
+          description: Created order
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+  /orders:bulk:
+    post:
+      summary: Bulk flood certificate ordering
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                loanIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                service:
+                  type: string
+                  enum: [FLOOD]
+                  default: FLOOD
+              required:
+                - loanIds
+      responses:
+        '202':
+          description: Bulk submission accepted
+  /orders/{id}:retry:
+    post:
+      summary: Retry an order with exponential backoff tracking
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Retry accepted
+  /dlq:
+    get:
+      summary: Inspect dead letter queue entries
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: query
+          name: status
+          schema:
+            type: string
+      responses:
+        '200':
+          description: DLQ entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DlqEntry'
+                required:
+                  - data
+  /dlq/{id}:replay:
+    post:
+      summary: Replay a DLQ entry
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Replay accepted
+  /webhooks/{vendor}:
+    post:
+      summary: Ingest vendor webhook payloads
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - in: path
+          name: vendor
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: X-Signature
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '202':
+          description: Webhook accepted for processing

--- a/docs/architecture/m6-slo-dashboards.md
+++ b/docs/architecture/m6-slo-dashboards.md
@@ -1,0 +1,38 @@
+# M6 Observability Dashboards
+
+**Last reviewed:** 2024-05-25
+
+## Overview
+Dashboards built on top of the existing OTLP streams. Each widget references metrics emitted by new API endpoints and Temporal workers.
+
+### 1. Task Queue Health
+- **Chart:** Heatmap of `app.tasks.accepted` per queue (sum) vs `task_events` count.
+- **Signals:**
+  - p95 `/v1/tasks` latency < 200ms (Fastify route).
+  - Count of blocked tasks (`task.state = BLOCKED`) per tenant.
+- **Alerts:** Trigger when overdue > 10% for 15 minutes.
+
+### 2. SLA Aggregation
+- **Chart:** Gauge for `sla.warning` vs `sla.overdue` derived from `SlaService` metrics.
+- **Supporting logs:** `api.sla` logger outputs with `tenant_id` tag.
+
+### 3. Orders Pipeline
+- **Chart:** Multi-series area chart showing `orders.submitted`, `orders.completed`, and `orders.failed` per vendor.
+- **Metrics:**
+  - `app.orders.total` (from list endpoint).
+  - Activity timers `worker.activities.SubmitOrder` and `worker.activities.RetryWithBackoff`.
+  - DLQ backlog from `dlq_entries` (SQL -> metric via collector).
+
+### 4. Webhook Verification
+- **Chart:** Success vs failure ratio for signature validation (`api.webhooks` span attribute `signature.valid`).
+- **Logs:** Pino logs with `signatureValid=false` flagged as WARN.
+- **Alert:** if failure rate > 1% over 10 minutes.
+
+### 5. Temporal Worker Health
+- **Chart:** Workflow runtime for `TaskRoutingWorkflow`, `OrderSubmissionWorkflow`, and `DlqReplayWorkflow`.
+- **Metrics:** queue depth, activity retries, DLQ move counts.
+
+## Implementation Notes
+- Add metric exporters in worker process to publish counters for `moveToDlqActivity` and `replayFromDlqActivity`.
+- Use existing Grafana template with OTEL data source; add folder `Milestone M6`.
+- Document SLO thresholds in runbooks referencing these dashboards.

--- a/docs/runbooks/dlq-replay.md
+++ b/docs/runbooks/dlq-replay.md
@@ -1,0 +1,40 @@
+# DLQ Replay Runbook (M6)
+
+**Last reviewed:** 2024-05-25
+
+## Scope
+Guides operators through safe replay of `dlq_entries` produced by Temporal workers, webhook ingestion, or vendor retries.
+
+## Preconditions
+- DLQ backlog confirmed via `/v1/dlq?status=PENDING`.
+- Vendor or upstream system is stable (no active outage runbook in progress).
+- Access to production console with tenant impersonation.
+
+## Replay Checklist
+1. **Snapshot current state**
+   ```bash
+   curl -H "Authorization: Bearer $TOKEN" \
+     "https://api.haizel.dev/v1/dlq?status=PENDING"
+   ```
+2. **Prioritize** by `source`:
+   - `orders.submit` first, then `webhooks.ingest`, then `tasks.route`.
+   - Verify `ref_id` still exists (task/order may be closed).
+3. **Warm cache**: run `/v1/sla/heatmap?scope=orders&range=week` to ensure UI reflects new SLA projections once replay succeeds.
+4. **Replay** using API:
+   ```bash
+   curl -X POST \
+     -H "Authorization: Bearer $TOKEN" \
+     -H "Idempotency-Key: $(uuidgen)" \
+     "https://api.haizel.dev/v1/dlq/${DLQ_ID}:replay"
+   ```
+5. **Monitor Temporal**: watch `dlq.replayed` metric and ensure correlated workflow completes.
+6. **Audit**: confirm `dlq_entries.status = 'REPLAYED'` and `last_seen_at` updated.
+
+## Failure Handling
+- If replay fails twice, set `status = 'ARCHIVED'` and open Jira ticket `OPS-<id>` with payload hash.
+- For serialization errors, export `payload_json` to secure bucket for engineering review.
+
+## Post-Run
+- Summarize runs in runbook log (date, count, outcome).
+- Update saved view in Orders Hub to reflect any recovered orders.
+- Trigger `ComputeSla` Temporal workflow if >25 records replayed to refresh heatmap.

--- a/docs/runbooks/vendor-outage.md
+++ b/docs/runbooks/vendor-outage.md
@@ -1,0 +1,48 @@
+# Vendor Outage Runbook (M6)
+
+**Last reviewed:** 2024-05-25
+
+## Purpose
+Coordinate response when a downstream vendor for Title, Flood, MI, SSA-89, or 4506-C orders experiences partial or total outage. Ensures customer communication, workload rerouting, and compliance timelines are maintained.
+
+## Detection
+- Temporal metrics `worker.activities.SubmitOrder` latency > 5s or failure ratio > 5%.
+- `/v1/orders` API showing surge in `FAILED` status with identical vendor.
+- Vendor health widget (web Orders Hub) displays `status = degraded|down`.
+- Alert from vendor monitoring or webhook inactivity for >15 minutes.
+
+## Immediate Actions
+1. **Acknowledge alert** in PagerDuty (or configured incident manager).
+2. **Freeze retries** for the vendor to avoid DLQ overload:
+   - Call `/v1/orders/{id}:retry` only after health checks recover.
+   - Temporarily disable automation by updating `vendor_accounts.status = 'paused'` via admin console.
+3. **Notify stakeholders**:
+   - Post summary in `#ops-broker` Slack channel.
+   - Email compliance lead if SLA at-risk > 10% of active orders.
+4. **Validate scope** using SQL:
+   ```sql
+   select vendor_id, count(*) as pending
+   from orders
+   where tenant_id = :tenant
+     and vendor_id = :vendor
+     and status in ('SUBMITTED','IN_PROGRESS')
+   group by vendor_id;
+   ```
+5. **Trigger reroute** if alternate vendor configured:
+   - Call `/v1/queues/route` with `preferredQueues` targeting fallback skillset.
+   - Update `queue_defs.routing_json` to temporarily bias away from impacted vendor.
+
+## Communication Template
+> Vendor {vendor_name} outage detected at {timestamp}. Orders automatically paused and rerouted where configured. Next update in 30 minutes.
+
+## Recovery Steps
+1. Confirm vendor status via official channel (portal/webhook recovery).
+2. Re-enable account: set `vendor_accounts.status = 'active'`.
+3. Replay DLQ entries via `/v1/dlq/{id}:replay` (batch using automation script).
+4. Monitor Temporal metrics for 15 minutes; ensure failure rate < 2% before resuming bulk flood operations.
+5. Post incident review in shared doc referencing task/event IDs.
+
+## Post-Incident
+- Create `task_events` entry summarizing outage (state transition to `blocked`).
+- File RCA within 48 hours including SLA impact and recovered orders count.
+- Update vendor health thresholds if detection lag > 5 minutes.

--- a/migrations/m6-tasks-orders/001-schema.sql
+++ b/migrations/m6-tasks-orders/001-schema.sql
@@ -1,0 +1,238 @@
+-- Tasks, queues, orders, and vendor integration schema for milestone M6
+set check_function_bodies = off;
+
+-- Enumerations
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'task_state') THEN
+    CREATE TYPE task_state AS ENUM ('NEW','IN_PROGRESS','BLOCKED','DONE');
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'order_service') THEN
+    CREATE TYPE order_service AS ENUM ('APPRAISAL','TITLE','FLOOD','MI','SSA89','4506-C');
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'order_status') THEN
+    CREATE TYPE order_status AS ENUM ('PENDING','DRAFT','SUBMITTED','IN_PROGRESS','COMPLETED','FAILED','CANCELED');
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'dlq_entry_status') THEN
+    CREATE TYPE dlq_entry_status AS ENUM ('PENDING','REPLAYED','ARCHIVED');
+  END IF;
+END;
+$$;
+
+-- Drop dependent tables to rebuild according to new contract
+DROP TABLE IF EXISTS task_events CASCADE;
+DROP TABLE IF EXISTS tasks CASCADE;
+DROP TABLE IF EXISTS queue_defs CASCADE;
+DROP TABLE IF EXISTS vendor_responses CASCADE;
+DROP TABLE IF EXISTS vendor_requests CASCADE;
+DROP TABLE IF EXISTS vendor_accounts CASCADE;
+DROP TABLE IF EXISTS webhooks CASCADE;
+DROP TABLE IF EXISTS vendors CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS dlq_entries CASCADE;
+
+-- Core task tables
+CREATE TABLE tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  loan_id uuid REFERENCES loans(id) ON DELETE CASCADE,
+  owner_user_id uuid REFERENCES users(id),
+  queue_key text NOT NULL,
+  type text NOT NULL,
+  state task_state NOT NULL DEFAULT 'NEW',
+  priority integer NOT NULL DEFAULT 3,
+  due_at timestamptz,
+  sla_due_at timestamptz,
+  tags text[] NOT NULL DEFAULT ARRAY[]::text[],
+  metadata_jsonb jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_tasks_tenant_state_queue_due ON tasks (tenant_id, state, queue_key, due_at);
+CREATE INDEX idx_tasks_tenant_owner_state ON tasks (tenant_id, owner_user_id, state);
+CREATE INDEX idx_tasks_tenant_sla ON tasks (tenant_id, sla_due_at);
+
+CREATE TABLE task_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  task_id uuid NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  state_from task_state,
+  state_to task_state,
+  payload_jsonb jsonb,
+  prev_hash text,
+  hash text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid
+);
+
+CREATE INDEX idx_task_events_tenant_task_created ON task_events (tenant_id, task_id, created_at);
+
+CREATE TABLE queue_defs (
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  key text NOT NULL,
+  name text NOT NULL,
+  skills text[] NOT NULL DEFAULT ARRAY[]::text[],
+  routing_json jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  PRIMARY KEY (tenant_id, key)
+);
+
+-- Vendor and order domain
+CREATE TABLE vendors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid REFERENCES tenants(id) ON DELETE CASCADE,
+  slug text NOT NULL,
+  name text NOT NULL,
+  services order_service[] NOT NULL,
+  health_json jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  CONSTRAINT vendors_tenant_slug_key UNIQUE (tenant_id, slug)
+);
+
+CREATE TABLE vendor_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  vendor_id uuid NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  display_name text NOT NULL,
+  skills text[] NOT NULL DEFAULT ARRAY[]::text[],
+  credentials_jsonb jsonb,
+  status text NOT NULL DEFAULT 'active',
+  last_synced_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  CONSTRAINT vendor_accounts_tenant_vendor_display_key UNIQUE (tenant_id, vendor_id, display_name)
+);
+
+CREATE TABLE orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  loan_id uuid REFERENCES loans(id) ON DELETE CASCADE,
+  service order_service NOT NULL,
+  status order_status NOT NULL DEFAULT 'PENDING',
+  vendor_id uuid REFERENCES vendors(id),
+  vendor_account_id uuid REFERENCES vendor_accounts(id),
+  sla_due_at timestamptz,
+  cost numeric(14,2),
+  request_json jsonb,
+  response_json jsonb,
+  metadata_jsonb jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  version integer NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_orders_tenant_status_service ON orders (tenant_id, status, service);
+CREATE INDEX idx_orders_tenant_loan ON orders (tenant_id, loan_id);
+
+CREATE TABLE vendor_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  order_id uuid REFERENCES orders(id) ON DELETE CASCADE,
+  vendor_id uuid NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  vendor_account_id uuid REFERENCES vendor_accounts(id),
+  service order_service NOT NULL,
+  status order_status NOT NULL DEFAULT 'PENDING',
+  attempt integer NOT NULL DEFAULT 1,
+  correlation_id text NOT NULL,
+  key_hash text,
+  request_hash text,
+  response_hash text,
+  response_payload jsonb,
+  request_json jsonb,
+  response_json jsonb,
+  latency_ms integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  CONSTRAINT vendor_requests_tenant_correlation_key UNIQUE (tenant_id, correlation_id)
+);
+
+CREATE INDEX idx_vendor_requests_tenant_vendor_service ON vendor_requests (tenant_id, vendor_id, service);
+CREATE UNIQUE INDEX idx_vendor_requests_tenant_key_hash ON vendor_requests (tenant_id, key_hash) WHERE key_hash IS NOT NULL;
+
+CREATE TABLE vendor_responses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  request_id uuid NOT NULL REFERENCES vendor_requests(id) ON DELETE CASCADE,
+  vendor_id uuid REFERENCES vendors(id),
+  status_code integer,
+  error_code text,
+  payload_json jsonb,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_vendor_responses_tenant_request ON vendor_responses (tenant_id, request_id);
+CREATE INDEX idx_vendor_responses_tenant_vendor ON vendor_responses (tenant_id, vendor_id);
+
+CREATE TABLE webhooks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  vendor_id uuid NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  request_id uuid REFERENCES vendor_requests(id) ON DELETE SET NULL,
+  external_id text,
+  signature text,
+  signature_valid boolean NOT NULL DEFAULT false,
+  payload_json jsonb NOT NULL,
+  headers_json jsonb,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz,
+  status text NOT NULL DEFAULT 'pending',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_webhooks_tenant_vendor_received ON webhooks (tenant_id, vendor_id, received_at);
+
+CREATE TABLE dlq_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid REFERENCES tenants(id) ON DELETE CASCADE,
+  source text NOT NULL,
+  ref_id text,
+  reason_code text NOT NULL,
+  attempts integer NOT NULL DEFAULT 0,
+  payload_json jsonb NOT NULL,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  status dlq_entry_status NOT NULL DEFAULT 'PENDING',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  replayed_at timestamptz
+);
+
+CREATE INDEX idx_dlq_entries_tenant_status ON dlq_entries (tenant_id, status);
+CREATE INDEX idx_dlq_entries_source_status ON dlq_entries (source, status);

--- a/migrations/m6-tasks-orders/002-rls.sql
+++ b/migrations/m6-tasks-orders/002-rls.sql
@@ -1,0 +1,64 @@
+-- Row level security policies for milestone M6 objects
+
+-- Enable RLS
+ALTER TABLE tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tasks FORCE ROW LEVEL SECURITY;
+ALTER TABLE task_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE task_events FORCE ROW LEVEL SECURITY;
+ALTER TABLE queue_defs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE queue_defs FORCE ROW LEVEL SECURITY;
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE orders FORCE ROW LEVEL SECURITY;
+ALTER TABLE vendors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendors FORCE ROW LEVEL SECURITY;
+ALTER TABLE vendor_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_accounts FORCE ROW LEVEL SECURITY;
+ALTER TABLE vendor_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_requests FORCE ROW LEVEL SECURITY;
+ALTER TABLE vendor_responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vendor_responses FORCE ROW LEVEL SECURITY;
+ALTER TABLE webhooks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE webhooks FORCE ROW LEVEL SECURITY;
+ALTER TABLE dlq_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dlq_entries FORCE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY tasks_tenant_isolation ON tasks
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY task_events_tenant_isolation ON task_events
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY queue_defs_tenant_isolation ON queue_defs
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY orders_tenant_isolation ON orders
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY vendors_tenant_visibility ON vendors
+  USING (tenant_id IS NULL OR tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY vendor_accounts_tenant_isolation ON vendor_accounts
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY vendor_requests_tenant_isolation ON vendor_requests
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY vendor_responses_tenant_isolation ON vendor_responses
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY webhooks_tenant_isolation ON webhooks
+  USING (tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());
+
+CREATE POLICY dlq_entries_tenant_isolation ON dlq_entries
+  USING (tenant_id IS NULL OR tenant_id = app.current_tenant())
+  WITH CHECK (tenant_id = app.current_tenant());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,38 @@ datasource db {
   url      = env("API_POSTGRES_URL")
 }
 
+enum TaskState {
+  NEW
+  IN_PROGRESS
+  BLOCKED
+  DONE
+}
+
+enum OrderService {
+  APPRAISAL
+  TITLE
+  FLOOD
+  MI
+  SSA89
+  IRS4506C @map("4506-C")
+}
+
+enum OrderStatus {
+  PENDING
+  DRAFT
+  SUBMITTED
+  IN_PROGRESS
+  COMPLETED
+  FAILED
+  CANCELED
+}
+
+enum DlqEntryStatus {
+  PENDING
+  REPLAYED
+  ARCHIVED
+}
+
 model Tenant {
   id         String        @id @default(uuid()) @db.Uuid
   slug       String        @unique
@@ -65,7 +97,7 @@ model User {
   tenant      Tenant      @relation(fields: [tenantId], references: [id])
   userRoles   UserRole[]
   loanParties LoanParty[]
-  tasksAssigned Task[]    @relation("TaskAssignee")
+  tasksOwned Task[]    @relation("TaskOwner")
   ownedConditions Condition[] @relation("ConditionAssignee")
   communications Communication[] @relation("CommunicationActor")
   accessAudits AccessAudit[]
@@ -444,24 +476,64 @@ model Condition {
 }
 
 model Task {
-  id        String   @id @default(uuid()) @db.Uuid
-  tenantId  String   @map("tenant_id") @db.Uuid
-  loanId    String?  @map("loan_id") @db.Uuid
-  title     String
-  description String?
-  status    String?
-  assigneeId  String?   @map("assignee") @db.Uuid
-  dueAt     DateTime? @map("due_at")
-  createdAt DateTime  @map("created_at") @default(now())
-  updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
-  createdBy String?   @map("created_by") @db.Uuid
-  updatedBy String?   @map("updated_by") @db.Uuid
-  version   Int       @default(1)
-  loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
-  assignee  User?     @relation("TaskAssignee", fields: [assigneeId], references: [id])
+  id           String     @id @default(uuid()) @db.Uuid
+  tenantId     String     @map("tenant_id") @db.Uuid
+  loanId       String?    @map("loan_id") @db.Uuid
+  ownerUserId  String?    @map("owner_user_id") @db.Uuid
+  queueKey     String     @map("queue_key")
+  type         String
+  state        TaskState  @default(NEW)
+  priority     Int        @default(3)
+  dueAt        DateTime?  @map("due_at")
+  slaDueAt     DateTime?  @map("sla_due_at")
+  tags         String[]   @default([])
+  metadata     Json?      @map("metadata_jsonb")
+  createdAt    DateTime   @map("created_at") @default(now())
+  updatedAt    DateTime   @map("updated_at") @default(now()) @updatedAt
+  createdBy    String?    @map("created_by") @db.Uuid
+  updatedBy    String?    @map("updated_by") @db.Uuid
+  version      Int        @default(1)
+  loan         Loan?      @relation(fields: [loanId], references: [id], onDelete: Cascade)
+  owner        User?      @relation("TaskOwner", fields: [ownerUserId], references: [id])
+  events       TaskEvent[]
 
-  @@index([tenantId, assigneeId, dueAt])
+  @@index([tenantId, state, queueKey, dueAt])
+  @@index([tenantId, ownerUserId, state])
   @@map("tasks")
+}
+
+model TaskEvent {
+  id          String   @id @default(uuid()) @db.Uuid
+  tenantId    String   @map("tenant_id") @db.Uuid
+  taskId      String   @map("task_id") @db.Uuid
+  eventType   String   @map("event_type")
+  stateFrom   TaskState? @map("state_from")
+  stateTo     TaskState? @map("state_to")
+  payload     Json?    @map("payload_jsonb")
+  prevHash    String?  @map("prev_hash")
+  hash        String
+  createdAt   DateTime @map("created_at") @default(now())
+  createdBy   String?  @map("created_by") @db.Uuid
+  task        Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId, taskId, createdAt])
+  @@map("task_events")
+}
+
+model QueueDef {
+  tenantId    String   @map("tenant_id") @db.Uuid
+  key         String
+  name        String
+  skills      String[]
+  routingJson Json     @map("routing_json")
+  createdAt   DateTime @map("created_at") @default(now())
+  updatedAt   DateTime @map("updated_at") @default(now()) @updatedAt
+  createdBy   String?  @map("created_by") @db.Uuid
+  updatedBy   String?  @map("updated_by") @db.Uuid
+  version     Int      @default(1)
+
+  @@id([tenantId, key])
+  @@map("queue_defs")
 }
 
 model Communication {
@@ -519,20 +591,168 @@ model Disclosure {
 }
 
 model Order {
-  id        String   @id @default(uuid()) @db.Uuid
-  tenantId  String   @map("tenant_id") @db.Uuid
-  loanId    String?  @map("loan_id") @db.Uuid
-  orderType String?  @map("order_type")
-  vendor    String?
-  status    String?
-  createdAt DateTime  @map("created_at") @default(now())
-  updatedAt DateTime  @map("updated_at") @default(now()) @updatedAt
-  createdBy String?   @map("created_by") @db.Uuid
-  updatedBy String?   @map("updated_by") @db.Uuid
-  version   Int       @default(1)
-  loan      Loan?     @relation(fields: [loanId], references: [id], onDelete: Cascade)
+  id             String        @id @default(uuid()) @db.Uuid
+  tenantId       String        @map("tenant_id") @db.Uuid
+  loanId         String?       @map("loan_id") @db.Uuid
+  service        OrderService  @map("service")
+  status         OrderStatus   @default(PENDING)
+  vendorId       String?       @map("vendor_id") @db.Uuid
+  vendorAccountId String?      @map("vendor_account_id") @db.Uuid
+  slaDueAt       DateTime?     @map("sla_due_at")
+  cost           Decimal?      @db.Decimal(14, 2)
+  requestJson    Json?         @map("request_json")
+  responseJson   Json?         @map("response_json")
+  metadata       Json?         @map("metadata_jsonb")
+  createdAt      DateTime      @map("created_at") @default(now())
+  updatedAt      DateTime      @map("updated_at") @default(now()) @updatedAt
+  createdBy      String?       @map("created_by") @db.Uuid
+  updatedBy      String?       @map("updated_by") @db.Uuid
+  version        Int           @default(1)
+  loan           Loan?         @relation(fields: [loanId], references: [id], onDelete: Cascade)
+  vendor         Vendor?       @relation(fields: [vendorId], references: [id])
+  vendorAccount  VendorAccount? @relation(fields: [vendorAccountId], references: [id])
+  requests       VendorRequest[]
 
+  @@index([tenantId, status, service])
+  @@index([tenantId, loanId])
   @@map("orders")
+}
+
+model Vendor {
+  id         String         @id @default(uuid()) @db.Uuid
+  tenantId   String?        @map("tenant_id") @db.Uuid
+  slug       String
+  name       String
+  services   OrderService[]
+  healthJson Json?          @map("health_json")
+  isActive   Boolean        @map("is_active") @default(true)
+  createdAt  DateTime       @map("created_at") @default(now())
+  updatedAt  DateTime       @map("updated_at") @default(now()) @updatedAt
+  createdBy  String?        @map("created_by") @db.Uuid
+  updatedBy  String?        @map("updated_by") @db.Uuid
+  version    Int            @default(1)
+  accounts   VendorAccount[]
+  orders     Order[]
+  requests   VendorRequest[]
+  responses  VendorResponse[]
+  webhooks   Webhook[]
+
+  @@unique([tenantId, slug])
+  @@map("vendors")
+}
+
+model VendorAccount {
+  id            String    @id @default(uuid()) @db.Uuid
+  tenantId      String    @map("tenant_id") @db.Uuid
+  vendorId      String    @map("vendor_id") @db.Uuid
+  displayName   String    @map("display_name")
+  skills        String[]  @default([])
+  credentials   Json?     @map("credentials_jsonb")
+  status        String    @default("active")
+  lastSyncedAt  DateTime? @map("last_synced_at")
+  createdAt     DateTime  @map("created_at") @default(now())
+  updatedAt     DateTime  @map("updated_at") @default(now()) @updatedAt
+  createdBy     String?   @map("created_by") @db.Uuid
+  updatedBy     String?   @map("updated_by") @db.Uuid
+  version       Int       @default(1)
+  vendor        Vendor    @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  orders        Order[]
+  requests      VendorRequest[]
+
+  @@unique([tenantId, vendorId, displayName])
+  @@map("vendor_accounts")
+}
+
+model VendorRequest {
+  id             String        @id @default(uuid()) @db.Uuid
+  tenantId       String        @map("tenant_id") @db.Uuid
+  orderId        String?       @map("order_id") @db.Uuid
+  vendorId       String        @map("vendor_id") @db.Uuid
+  vendorAccountId String?      @map("vendor_account_id") @db.Uuid
+  service        OrderService  @map("service")
+  status         OrderStatus   @default(PENDING)
+  attempt        Int           @default(1)
+  correlationId  String        @map("correlation_id")
+  keyHash        String?       @map("key_hash")
+  requestHash    String?       @map("request_hash")
+  responseHash   String?       @map("response_hash")
+  responsePayload Json?        @map("response_payload")
+  requestJson    Json?         @map("request_json")
+  responseJson   Json?         @map("response_json")
+  latencyMs      Int?          @map("latency_ms")
+  createdAt      DateTime      @map("created_at") @default(now())
+  updatedAt      DateTime      @map("updated_at") @default(now()) @updatedAt
+  createdBy      String?       @map("created_by") @db.Uuid
+  updatedBy      String?       @map("updated_by") @db.Uuid
+  order          Order?        @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  vendor         Vendor        @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  vendorAccount  VendorAccount? @relation(fields: [vendorAccountId], references: [id])
+  responses      VendorResponse[]
+  webhooks       Webhook[]
+
+  @@unique([tenantId, correlationId])
+  @@unique([tenantId, keyHash])
+  @@index([tenantId, vendorId, service])
+  @@map("vendor_requests")
+}
+
+model VendorResponse {
+  id            String   @id @default(uuid()) @db.Uuid
+  tenantId      String   @map("tenant_id") @db.Uuid
+  requestId     String   @map("request_id") @db.Uuid
+  vendorId      String?  @map("vendor_id") @db.Uuid
+  statusCode    Int?     @map("status_code")
+  errorCode     String?  @map("error_code")
+  payload       Json?    @map("payload_json")
+  receivedAt    DateTime @map("received_at") @default(now())
+  createdAt     DateTime @map("created_at") @default(now())
+  request       VendorRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  vendor        Vendor?  @relation(fields: [vendorId], references: [id])
+
+  @@index([tenantId, requestId])
+  @@index([tenantId, vendorId])
+  @@map("vendor_responses")
+}
+
+model Webhook {
+  id             String    @id @default(uuid()) @db.Uuid
+  tenantId       String    @map("tenant_id") @db.Uuid
+  vendorId       String    @map("vendor_id") @db.Uuid
+  requestId      String?   @map("request_id") @db.Uuid
+  externalId     String?   @map("external_id")
+  signature      String?   @map("signature")
+  signatureValid Boolean   @map("signature_valid") @default(false)
+  payload        Json      @map("payload_json")
+  headers        Json?     @map("headers_json")
+  receivedAt     DateTime  @map("received_at") @default(now())
+  processedAt    DateTime? @map("processed_at")
+  status         String    @default("pending")
+  createdAt      DateTime  @map("created_at") @default(now())
+  vendor         Vendor    @relation(fields: [vendorId], references: [id], onDelete: Cascade)
+  request        VendorRequest? @relation(fields: [requestId], references: [id])
+
+  @@index([tenantId, vendorId, receivedAt])
+  @@map("webhooks")
+}
+
+model DlqEntry {
+  id           String         @id @default(uuid()) @db.Uuid
+  tenantId     String?        @map("tenant_id") @db.Uuid
+  source       String
+  refId        String?        @map("ref_id")
+  reasonCode   String         @map("reason_code")
+  attempts     Int            @default(0)
+  payloadJson  Json           @map("payload_json")
+  firstSeenAt  DateTime       @map("first_seen_at") @default(now())
+  lastSeenAt   DateTime       @map("last_seen_at") @default(now())
+  status       DlqEntryStatus @default(PENDING)
+  createdAt    DateTime       @map("created_at") @default(now())
+  updatedAt    DateTime       @map("updated_at") @default(now()) @updatedAt
+  replayedAt   DateTime?      @map("replayed_at")
+
+  @@index([tenantId, status])
+  @@index([source, status])
+  @@map("dlq_entries")
 }
 
 model PricingQuote {


### PR DESCRIPTION
## Summary
- add Prisma schema updates and migrations for tasks, queues, orders, vendor, webhook, and DLQ entities with tenant RLS
- implement NestJS operations module with task, SLA, order, DLQ, and webhook endpoints plus Temporal worker scaffolding
- deliver Next.js dashboards, runbooks, and OpenAPI documentation for milestone M6

## Testing
- pnpm lint --filter api *(fails: missing @haizel/eslint config referenced by repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e19c94d7788332b396d525973eab09